### PR TITLE
Initial batch of uniti tests for aggregatestore and eventstore/memory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+.PHONY: info utest lint
+
+# Show available targets.
+info:
+	@echo "Targets:"
+	@echo "  utest    Run unit tests"
+
+# Run unit tests.
+utest: _require_go
+	go test -cover ./...
+
+# Run linters.
+# See https://golangci-lint.run/usage/linters/ for details on specific linters.
+lint: _require_golangci_lint
+	golangci-lint run
+
+#
+# dependencies
+#
+
+_require_go:
+ifneq (, $(shell which go))
+	@true
+else
+	@echo "This target reqires Go: https://golang.org/doc/install"
+	@false
+endif
+
+_require_golangci_lint:
+ifneq (, $(shell which golangci-lint))
+	@true
+else
+	@echo "This target reqires golangci-lint: https://golangci-lint.run/usage/install/"
+	@false
+endif

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Event sourcing enables you to model your application as a series of state-changi
 
 Estoria provides composable components for implementing event sourcing in a Go application, including:
 
-- Event-based aggregegate state management
+- Event-based aggregate state management
 - Flexible event store implementations
 - Transactional outbox processing
 - Aggregate snapshotting

--- a/aggregatecache/in_memory.go
+++ b/aggregatecache/in_memory.go
@@ -178,14 +178,14 @@ func (c *InMemoryCache[E]) evictLRU() {
 }
 
 func (c *InMemoryCache[E]) evictTTL() {
-	for id, entry := range c.entries {
+	for aggregateID, entry := range c.entries {
 		if c.evictionPolicy.MaxAge > 0 && time.Since(entry.added) > c.evictionPolicy.MaxAge {
-			delete(c.entries, id)
+			delete(c.entries, aggregateID)
 			continue
 		}
 
 		if c.evictionPolicy.MaxIdle > 0 && time.Since(entry.lastUsed) > c.evictionPolicy.MaxIdle {
-			delete(c.entries, id)
+			delete(c.entries, aggregateID)
 			continue
 		}
 	}

--- a/aggregatestore/aggregate.go
+++ b/aggregatestore/aggregate.go
@@ -27,6 +27,8 @@ func (a *Aggregate[E]) Append(events ...*AggregateEvent) error {
 
 // Entity returns the aggregate's underlying entity.
 // The entity is the domain model whose state the aggregate manages.
+//
+//nolint:ireturn // the return type is a type parameter
 func (a *Aggregate[E]) Entity() E {
 	return a.state.Entity()
 }
@@ -119,6 +121,8 @@ func (a *AggregateState[E]) WillSave(events []*AggregateEvent) {
 }
 
 // Entity returns the aggregate's entity.
+//
+//nolint:ireturn // the return type is a type parameter
 func (a *AggregateState[E]) Entity() E {
 	return a.entity
 }
@@ -148,7 +152,7 @@ func (a *AggregateState[E]) Version() int64 {
 	return a.version
 }
 
-// An AggregateEvent is an event that that applies to an aggregate to change its state.
+// An AggregateEvent is an event that applies to an aggregate to change its state.
 // It consists of a unique ID, a timestamp, and an entity event, which holds data specific
 // to an event representinig an incremental change to the underlying entity.
 type AggregateEvent struct {

--- a/aggregatestore/aggregate_store.go
+++ b/aggregatestore/aggregate_store.go
@@ -2,7 +2,6 @@ package aggregatestore
 
 import (
 	"context"
-	"errors"
 
 	"github.com/go-estoria/estoria"
 	"github.com/go-estoria/estoria/typeid"
@@ -47,12 +46,90 @@ type HydrateOptions struct {
 // SaveOptions are options for saving an aggregate.
 type SaveOptions struct {
 	// SkipApply skips applying the events to the entity.
-	// This is useful in situations where it is desireable to delay the application of events,
+	// This is useful in situations where it is desirable to delay the application of events,
 	// such as when wrapping the aggregate store with additional functionality.
 	//
 	// Default: false
 	SkipApply bool
 }
 
-// ErrAggregateNotFound is returned when an aggregate is not found.
-var ErrAggregateNotFound = errors.New("aggregate not found")
+type AggregateNotFoundError struct {
+	AggregateID typeid.UUID
+}
+
+func (e AggregateNotFoundError) Error() string {
+	return "aggregate not found: " + e.AggregateID.String()
+}
+
+type InitializeAggregateStoreError struct {
+	Operation string
+	Err       error
+}
+
+func (e InitializeAggregateStoreError) Error() string {
+	if e.Operation == "" {
+		return e.Err.Error()
+	}
+
+	return e.Operation + ": " + e.Err.Error()
+}
+
+// A CreateAggregateError is an error that occurred while creating an aggregate.
+type CreateAggregateError struct {
+	AggregateID typeid.UUID
+	Operation   string
+	Err         error
+}
+
+func (e CreateAggregateError) Error() string {
+	if e.Operation == "" {
+		return e.Err.Error()
+	}
+
+	return e.Operation + ": " + e.Err.Error()
+}
+
+// A LoadAggregateError is an error that occurred while loading an aggregate.
+type LoadAggregateError struct {
+	AggregateID typeid.UUID
+	Operation   string
+	Err         error
+}
+
+func (e LoadAggregateError) Error() string {
+	if e.Operation == "" {
+		return e.Err.Error()
+	}
+
+	return e.Operation + ": " + e.Err.Error()
+}
+
+// A HydrateAggregateError is an error that occurred while hydrating an aggregate.
+type HydrateAggregateError struct {
+	AggregateID typeid.UUID
+	Operation   string
+	Err         error
+}
+
+func (e HydrateAggregateError) Error() string {
+	if e.Operation == "" {
+		return e.Err.Error()
+	}
+
+	return e.Operation + ": " + e.Err.Error()
+}
+
+// A SaveAggregateError is an error that occurred while saving an aggregate.
+type SaveAggregateError struct {
+	AggregateID typeid.UUID
+	Operation   string
+	Err         error
+}
+
+func (e SaveAggregateError) Error() string {
+	if e.Operation == "" {
+		return e.Err.Error()
+	}
+
+	return e.Operation + ": " + e.Err.Error()
+}

--- a/aggregatestore/cached_store.go
+++ b/aggregatestore/cached_store.go
@@ -63,7 +63,7 @@ func (s *CachedStore[E]) Hydrate(ctx context.Context, aggregate *Aggregate[E], o
 // Save saves an aggregate.
 func (s *CachedStore[E]) Save(ctx context.Context, aggregate *Aggregate[E], opts SaveOptions) error {
 	if err := s.inner.Save(ctx, aggregate, opts); err != nil {
-		return err
+		return SaveAggregateError{AggregateID: aggregate.ID(), Operation: "saving to inner store", Err: err}
 	}
 
 	if err := s.cache.PutAggregate(ctx, aggregate); err != nil {

--- a/aggregatestore/cached_store_test.go
+++ b/aggregatestore/cached_store_test.go
@@ -1,0 +1,539 @@
+package aggregatestore_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/go-estoria/estoria"
+	"github.com/go-estoria/estoria/aggregatecache"
+	"github.com/go-estoria/estoria/aggregatestore"
+	"github.com/go-estoria/estoria/typeid"
+	"github.com/gofrs/uuid/v5"
+)
+
+type mockStore[E estoria.Entity] struct {
+	newAggregate      *aggregatestore.Aggregate[E]
+	newErr            error
+	loadedAggregate   *aggregatestore.Aggregate[E]
+	loadErr           error
+	hydratedAggregate *aggregatestore.Aggregate[E]
+	hydrateErr        error
+	savedAggregate    *aggregatestore.Aggregate[E]
+	saveErr           error
+}
+
+func (s *mockStore[E]) New(id uuid.UUID) (*aggregatestore.Aggregate[E], error) {
+	return s.newAggregate, s.newErr
+}
+
+func (s *mockStore[E]) Load(_ context.Context, id typeid.UUID, opts aggregatestore.LoadOptions) (*aggregatestore.Aggregate[E], error) {
+	return s.loadedAggregate, s.loadErr
+}
+
+func (s *mockStore[E]) Hydrate(_ context.Context, aggregate *aggregatestore.Aggregate[E], opts aggregatestore.HydrateOptions) error {
+	if aggregate != nil && s.hydratedAggregate != nil {
+		*aggregate = *s.hydratedAggregate
+	}
+
+	return s.hydrateErr
+}
+
+func (s *mockStore[E]) Save(_ context.Context, aggregate *aggregatestore.Aggregate[E], opts aggregatestore.SaveOptions) error {
+	if aggregate != nil && s.savedAggregate != nil {
+		*aggregate = *s.savedAggregate
+	}
+
+	return s.saveErr
+}
+
+type mockCache[E estoria.Entity] struct {
+	getAggregateErr error
+	putAggregateErr error
+}
+
+func (c *mockCache[E]) GetAggregate(_ context.Context, _ typeid.UUID) (*aggregatestore.Aggregate[E], error) {
+	return nil, c.getAggregateErr
+}
+
+func (c *mockCache[E]) PutAggregate(_ context.Context, _ *aggregatestore.Aggregate[E]) error {
+	return c.putAggregateErr
+}
+
+func TestNewCachedStore(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name      string
+		haveInner func() aggregatestore.Store[*mockEntity]
+		haveCache func() aggregatestore.AggregateCache[*mockEntity]
+		wantErr   error
+	}{
+		{
+			name: "creates a new cached store",
+			haveInner: func() aggregatestore.Store[*mockEntity] {
+				return &mockStore[*mockEntity]{}
+			},
+			haveCache: func() aggregatestore.AggregateCache[*mockEntity] {
+				return aggregatecache.NewInMemoryCache[*mockEntity]()
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotStore := aggregatestore.NewCachedStore(tt.haveInner(), tt.haveCache())
+
+			if gotStore == nil {
+				t.Error("unexpected nil store")
+			}
+		})
+	}
+}
+
+func TestCachedStore_New(t *testing.T) {
+	t.Parallel()
+
+	aggregateID := typeid.Must(typeid.NewUUID("mockentity")).(typeid.UUID)
+
+	for _, tt := range []struct {
+		name          string
+		haveInner     func() aggregatestore.Store[*mockEntity]
+		haveCache     func() aggregatestore.AggregateCache[*mockEntity]
+		wantAggregate *aggregatestore.Aggregate[*mockEntity]
+		wantErr       error
+	}{
+		{
+			name: "creates a new aggregate using the inner store",
+			haveInner: func() aggregatestore.Store[*mockEntity] {
+				return &mockStore[*mockEntity]{
+					newAggregate: func() *aggregatestore.Aggregate[*mockEntity] {
+						agg := &aggregatestore.Aggregate[*mockEntity]{}
+						agg.State().SetEntityAtVersion(&mockEntity{ID: aggregateID}, 42)
+						return agg
+					}(),
+				}
+			},
+			haveCache: func() aggregatestore.AggregateCache[*mockEntity] {
+				return aggregatecache.NewInMemoryCache[*mockEntity]()
+			},
+			wantAggregate: func() *aggregatestore.Aggregate[*mockEntity] {
+				agg := &aggregatestore.Aggregate[*mockEntity]{}
+				agg.State().SetEntityAtVersion(&mockEntity{ID: aggregateID}, 42)
+				return agg
+			}(),
+		},
+		{
+			name: "returns an error when the inner store returns an error",
+			haveInner: func() aggregatestore.Store[*mockEntity] {
+				return &mockStore[*mockEntity]{
+					newErr: errors.New("mock error"),
+				}
+			},
+			haveCache: func() aggregatestore.AggregateCache[*mockEntity] {
+				return aggregatecache.NewInMemoryCache[*mockEntity]()
+			},
+			wantErr: errors.New("mock error"),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			store := aggregatestore.NewCachedStore(tt.haveInner(), tt.haveCache())
+			if store == nil {
+				t.Fatal("unexpected nil store")
+			}
+
+			gotAggregate, gotErr := store.New(aggregateID.UUID())
+
+			if tt.wantErr != nil {
+				if gotErr == nil || gotErr.Error() != tt.wantErr.Error() {
+					t.Errorf("want error: %v, got: %v", tt.wantErr, gotErr)
+				}
+				return
+			}
+
+			if gotErr != nil {
+				t.Errorf("unexpected error: %v", gotErr)
+			} else if gotAggregate == nil {
+				t.Errorf("unexpected nil aggregate")
+			}
+
+			// aggregate has the correct ID
+			if gotAggregate.ID().String() != typeid.FromUUID("mockentity", aggregateID.UUID()).String() {
+				t.Errorf("want aggregate ID %s, got %s", typeid.FromUUID("mockentity", aggregateID.UUID()), gotAggregate.ID())
+			}
+			// aggregate has the correct version
+			if gotAggregate.Version() != tt.wantAggregate.Version() {
+				t.Errorf("want aggregate version %d, got %d", tt.wantAggregate.Version(), gotAggregate.Version())
+			}
+		})
+	}
+}
+
+func TestCachedStore_Load(t *testing.T) {
+	t.Parallel()
+
+	aggregateID := typeid.Must(typeid.NewUUID("mockentity")).(typeid.UUID)
+
+	for _, tt := range []struct {
+		name          string
+		haveInner     func() aggregatestore.Store[*mockEntity]
+		haveCache     func() aggregatestore.AggregateCache[*mockEntity]
+		haveOpts      aggregatestore.LoadOptions
+		wantAggregate *aggregatestore.Aggregate[*mockEntity]
+		wantErr       error
+	}{
+		{
+			name: "returns an aggregate from the cache when available",
+			haveInner: func() aggregatestore.Store[*mockEntity] {
+				return &mockStore[*mockEntity]{
+					loadErr: errors.New("unexpected attempt to load aggregate from inner store"),
+				}
+			},
+			haveCache: func() aggregatestore.AggregateCache[*mockEntity] {
+				cache := aggregatecache.NewInMemoryCache[*mockEntity]()
+				cache.PutAggregate(context.Background(), func() *aggregatestore.Aggregate[*mockEntity] {
+					agg := &aggregatestore.Aggregate[*mockEntity]{}
+					agg.State().SetEntityAtVersion(&mockEntity{ID: aggregateID}, 42)
+					return agg
+				}())
+				return cache
+			},
+			wantAggregate: func() *aggregatestore.Aggregate[*mockEntity] {
+				agg := &aggregatestore.Aggregate[*mockEntity]{}
+				agg.State().SetEntityAtVersion(&mockEntity{ID: aggregateID}, 42)
+				return agg
+			}(),
+		},
+		{
+			name: "returns an aggregate from the inner store when the aggregate is not found in the cache",
+			haveInner: func() aggregatestore.Store[*mockEntity] {
+				return &mockStore[*mockEntity]{
+					loadedAggregate: func() *aggregatestore.Aggregate[*mockEntity] {
+						agg := &aggregatestore.Aggregate[*mockEntity]{}
+						agg.State().SetEntityAtVersion(&mockEntity{ID: aggregateID}, 42)
+						return agg
+					}(),
+				}
+			},
+			haveCache: func() aggregatestore.AggregateCache[*mockEntity] {
+				return aggregatecache.NewInMemoryCache[*mockEntity]()
+			},
+			wantAggregate: func() *aggregatestore.Aggregate[*mockEntity] {
+				agg := &aggregatestore.Aggregate[*mockEntity]{}
+				agg.State().SetEntityAtVersion(&mockEntity{ID: aggregateID}, 42)
+				return agg
+			}(),
+		},
+		{
+			name: "returns an aggregate from the inner store when the cache returns an error",
+			haveInner: func() aggregatestore.Store[*mockEntity] {
+				return &mockStore[*mockEntity]{
+					loadedAggregate: func() *aggregatestore.Aggregate[*mockEntity] {
+						agg := &aggregatestore.Aggregate[*mockEntity]{}
+						agg.State().SetEntityAtVersion(&mockEntity{ID: aggregateID}, 42)
+						return agg
+					}(),
+				}
+			},
+			haveCache: func() aggregatestore.AggregateCache[*mockEntity] {
+				return &mockCache[*mockEntity]{
+					getAggregateErr: errors.New("mock error"),
+				}
+			},
+			wantAggregate: func() *aggregatestore.Aggregate[*mockEntity] {
+				agg := &aggregatestore.Aggregate[*mockEntity]{}
+				agg.State().SetEntityAtVersion(&mockEntity{ID: aggregateID}, 42)
+				return agg
+			}(),
+		},
+		{
+			name: "returns an error when the inner store returns an error",
+			haveInner: func() aggregatestore.Store[*mockEntity] {
+				return &mockStore[*mockEntity]{
+					loadErr: errors.New("mock error"),
+				}
+			},
+			haveCache: func() aggregatestore.AggregateCache[*mockEntity] {
+				return aggregatecache.NewInMemoryCache[*mockEntity]()
+			},
+			wantErr: errors.New("mock error"),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			store := aggregatestore.NewCachedStore(tt.haveInner(), tt.haveCache())
+			if store == nil {
+				t.Fatal("unexpected nil store")
+			}
+
+			gotAggregate, gotErr := store.Load(context.Background(), aggregateID, tt.haveOpts)
+
+			if tt.wantErr != nil {
+				if gotErr == nil || gotErr.Error() != tt.wantErr.Error() {
+					t.Errorf("want error: %v, got: %v", tt.wantErr, gotErr)
+				}
+				return
+			}
+
+			if gotErr != nil {
+				t.Errorf("unexpected error: %v", gotErr)
+			} else if gotAggregate == nil {
+				t.Errorf("unexpected nil aggregate")
+			}
+
+			// aggregate has the correct ID
+			if gotAggregate.ID().String() != typeid.FromUUID("mockentity", aggregateID.UUID()).String() {
+				t.Errorf("want aggregate ID %s, got %s", typeid.FromUUID("mockentity", aggregateID.UUID()), gotAggregate.ID())
+			}
+			// aggregate has the correct version
+			if gotAggregate.Version() != tt.wantAggregate.Version() {
+				t.Errorf("want aggregate version %d, got %d", tt.wantAggregate.Version(), gotAggregate.Version())
+			}
+		})
+	}
+}
+
+func TestCachedStore_Hydrate(t *testing.T) {
+	t.Parallel()
+
+	aggregateID := typeid.Must(typeid.NewUUID("mockentity")).(typeid.UUID)
+
+	for _, tt := range []struct {
+		name          string
+		haveInner     func() aggregatestore.Store[*mockEntity]
+		haveCache     func() aggregatestore.AggregateCache[*mockEntity]
+		haveOpts      aggregatestore.HydrateOptions
+		haveAggregate func() *aggregatestore.Aggregate[*mockEntity]
+		wantAggregate *aggregatestore.Aggregate[*mockEntity]
+		wantErr       error
+	}{
+		{
+			name: "hydrates an aggregate using the inner store",
+			haveInner: func() aggregatestore.Store[*mockEntity] {
+				return &mockStore[*mockEntity]{
+					hydratedAggregate: func() *aggregatestore.Aggregate[*mockEntity] {
+						agg := &aggregatestore.Aggregate[*mockEntity]{}
+						agg.State().SetEntityAtVersion(&mockEntity{ID: aggregateID}, 42)
+						return agg
+					}(),
+				}
+			},
+			haveCache: func() aggregatestore.AggregateCache[*mockEntity] {
+				return aggregatecache.NewInMemoryCache[*mockEntity]()
+			},
+			haveAggregate: func() *aggregatestore.Aggregate[*mockEntity] {
+				agg := &aggregatestore.Aggregate[*mockEntity]{}
+				agg.State().SetEntityAtVersion(&mockEntity{ID: aggregateID}, 0)
+				return agg
+			},
+			wantAggregate: func() *aggregatestore.Aggregate[*mockEntity] {
+				agg := &aggregatestore.Aggregate[*mockEntity]{}
+				agg.State().SetEntityAtVersion(&mockEntity{ID: aggregateID}, 42)
+				return agg
+			}(),
+		},
+		{
+			name: "returns an error when the inner store returns an error",
+			haveInner: func() aggregatestore.Store[*mockEntity] {
+				return &mockStore[*mockEntity]{
+					hydrateErr: errors.New("mock error"),
+				}
+			},
+			haveCache: func() aggregatestore.AggregateCache[*mockEntity] {
+				return aggregatecache.NewInMemoryCache[*mockEntity]()
+			},
+			haveAggregate: func() *aggregatestore.Aggregate[*mockEntity] {
+				return nil
+			},
+			wantErr: errors.New("mock error"),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			store := aggregatestore.NewCachedStore(tt.haveInner(), tt.haveCache())
+			if store == nil {
+				t.Fatal("unexpected nil store")
+			}
+
+			gotAggregate := tt.haveAggregate()
+			gotErr := store.Hydrate(context.Background(), gotAggregate, tt.haveOpts)
+
+			if tt.wantErr != nil {
+				if gotErr == nil || gotErr.Error() != tt.wantErr.Error() {
+					t.Errorf("want error: %v, got: %v", tt.wantErr, gotErr)
+				}
+				return
+			}
+
+			if gotErr != nil {
+				t.Errorf("unexpected error: %v", gotErr)
+			} else if gotAggregate == nil {
+				t.Errorf("unexpected nil aggregate")
+			}
+
+			// aggregate has the correct ID
+			if gotAggregate.ID().String() != typeid.FromUUID("mockentity", aggregateID.UUID()).String() {
+				t.Errorf("want aggregate ID %s, got %s", typeid.FromUUID("mockentity", aggregateID.UUID()), gotAggregate.ID())
+			}
+			// aggregate has the correct version
+			if gotAggregate.Version() != tt.wantAggregate.Version() {
+				t.Errorf("want aggregate version %d, got %d", tt.wantAggregate.Version(), gotAggregate.Version())
+			}
+		})
+	}
+}
+
+func TestCachedStore_Save(t *testing.T) {
+	t.Parallel()
+
+	aggregateID := typeid.Must(typeid.NewUUID("mockentity")).(typeid.UUID)
+
+	for _, tt := range []struct {
+		name                string
+		haveInner           func() aggregatestore.Store[*mockEntity]
+		haveCache           func() aggregatestore.AggregateCache[*mockEntity]
+		haveOpts            aggregatestore.SaveOptions
+		haveAggregate       func() *aggregatestore.Aggregate[*mockEntity]
+		wantAggregate       *aggregatestore.Aggregate[*mockEntity]
+		wantCachedAggregate *aggregatestore.Aggregate[*mockEntity]
+		wantErr             error
+	}{
+		{
+			name: "saves an aggregate using the inner store and adds the aggregate to the cache",
+			haveInner: func() aggregatestore.Store[*mockEntity] {
+				return &mockStore[*mockEntity]{
+					savedAggregate: func() *aggregatestore.Aggregate[*mockEntity] {
+						agg := &aggregatestore.Aggregate[*mockEntity]{}
+						agg.State().SetEntityAtVersion(&mockEntity{ID: aggregateID}, 42)
+						return agg
+					}(),
+				}
+			},
+			haveCache: func() aggregatestore.AggregateCache[*mockEntity] {
+				return aggregatecache.NewInMemoryCache[*mockEntity]()
+			},
+			haveAggregate: func() *aggregatestore.Aggregate[*mockEntity] {
+				agg := &aggregatestore.Aggregate[*mockEntity]{}
+				agg.State().SetEntityAtVersion(&mockEntity{ID: aggregateID}, 0)
+				return agg
+			},
+			wantAggregate: func() *aggregatestore.Aggregate[*mockEntity] {
+				agg := &aggregatestore.Aggregate[*mockEntity]{}
+				agg.State().SetEntityAtVersion(&mockEntity{ID: aggregateID}, 42)
+				return agg
+			}(),
+			wantCachedAggregate: func() *aggregatestore.Aggregate[*mockEntity] {
+				agg := &aggregatestore.Aggregate[*mockEntity]{}
+				agg.State().SetEntityAtVersion(&mockEntity{ID: aggregateID}, 42)
+				return agg
+			}(),
+		},
+		{
+			name: "returns an error when the inner store returns an error",
+			haveInner: func() aggregatestore.Store[*mockEntity] {
+				return &mockStore[*mockEntity]{
+					saveErr: errors.New("mock error"),
+				}
+			},
+			haveCache: func() aggregatestore.AggregateCache[*mockEntity] {
+				return aggregatecache.NewInMemoryCache[*mockEntity]()
+			},
+			haveAggregate: func() *aggregatestore.Aggregate[*mockEntity] {
+				agg := &aggregatestore.Aggregate[*mockEntity]{}
+				agg.State().SetEntityAtVersion(&mockEntity{ID: aggregateID}, 42)
+				return agg
+			},
+			wantErr: errors.New("saving to inner store: mock error"),
+		},
+		{
+			name: "does not return an error when failing to add the aggregate to the cache",
+			haveInner: func() aggregatestore.Store[*mockEntity] {
+				return &mockStore[*mockEntity]{
+					savedAggregate: func() *aggregatestore.Aggregate[*mockEntity] {
+						agg := &aggregatestore.Aggregate[*mockEntity]{}
+						agg.State().SetEntityAtVersion(&mockEntity{ID: aggregateID}, 42)
+						return agg
+					}(),
+				}
+			},
+			haveCache: func() aggregatestore.AggregateCache[*mockEntity] {
+				return &mockCache[*mockEntity]{
+					putAggregateErr: errors.New("mock error"),
+				}
+			},
+			haveAggregate: func() *aggregatestore.Aggregate[*mockEntity] {
+				agg := &aggregatestore.Aggregate[*mockEntity]{}
+				agg.State().SetEntityAtVersion(&mockEntity{ID: aggregateID}, 0)
+				return agg
+			},
+			wantAggregate: func() *aggregatestore.Aggregate[*mockEntity] {
+				agg := &aggregatestore.Aggregate[*mockEntity]{}
+				agg.State().SetEntityAtVersion(&mockEntity{ID: aggregateID}, 42)
+				return agg
+			}(),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			haveCache := tt.haveCache()
+
+			store := aggregatestore.NewCachedStore(tt.haveInner(), haveCache)
+			if store == nil {
+				t.Fatal("unexpected nil store")
+			}
+
+			gotAggregate := tt.haveAggregate()
+			gotErr := store.Save(context.Background(), gotAggregate, tt.haveOpts)
+
+			if tt.wantErr != nil {
+				if gotErr == nil || gotErr.Error() != tt.wantErr.Error() {
+					t.Errorf("want error: %v, got: %v", tt.wantErr, gotErr)
+				}
+				return
+			}
+
+			if gotErr != nil {
+				t.Errorf("unexpected error: %v", gotErr)
+			} else if gotAggregate == nil {
+				t.Errorf("unexpected nil aggregate")
+			}
+
+			// aggregate has the correct ID
+			if gotAggregate.ID().String() != typeid.FromUUID("mockentity", aggregateID.UUID()).String() {
+				t.Errorf("want aggregate ID %s, got %s", typeid.FromUUID("mockentity", aggregateID.UUID()), gotAggregate.ID())
+			}
+			// aggregate has the correct version
+			if gotAggregate.Version() != tt.wantAggregate.Version() {
+				t.Errorf("want aggregate version %d, got %d", tt.wantAggregate.Version(), gotAggregate.Version())
+			}
+
+			if tt.wantCachedAggregate == nil {
+				return
+			}
+
+			gotCachedAggregate, gotErr := haveCache.GetAggregate(context.Background(), aggregateID)
+			if gotErr != nil {
+				t.Fatalf("unexpected error getting cached aggregate: %v", gotErr)
+			}
+
+			if gotCachedAggregate == nil {
+				t.Errorf("unexpected nil cached aggregate")
+				return
+			}
+
+			// cached aggregate has the correct ID
+			if gotCachedAggregate.ID().String() != tt.wantCachedAggregate.ID().String() {
+				t.Errorf("want cached aggregate ID %s, got %s", tt.wantCachedAggregate.ID(), gotCachedAggregate.ID())
+			}
+			// cached aggregate has the correct version
+			if gotCachedAggregate.Version() != tt.wantCachedAggregate.Version() {
+				t.Errorf("want cached aggregate version %d, got %d", tt.wantCachedAggregate.Version(), gotCachedAggregate.Version())
+			}
+		})
+	}
+}

--- a/aggregatestore/cached_store_test.go
+++ b/aggregatestore/cached_store_test.go
@@ -23,15 +23,15 @@ type mockStore[E estoria.Entity] struct {
 	saveErr           error
 }
 
-func (s *mockStore[E]) New(id uuid.UUID) (*aggregatestore.Aggregate[E], error) {
+func (s *mockStore[E]) New(_ uuid.UUID) (*aggregatestore.Aggregate[E], error) {
 	return s.newAggregate, s.newErr
 }
 
-func (s *mockStore[E]) Load(_ context.Context, id typeid.UUID, opts aggregatestore.LoadOptions) (*aggregatestore.Aggregate[E], error) {
+func (s *mockStore[E]) Load(_ context.Context, _ typeid.UUID, _ aggregatestore.LoadOptions) (*aggregatestore.Aggregate[E], error) {
 	return s.loadedAggregate, s.loadErr
 }
 
-func (s *mockStore[E]) Hydrate(_ context.Context, aggregate *aggregatestore.Aggregate[E], opts aggregatestore.HydrateOptions) error {
+func (s *mockStore[E]) Hydrate(_ context.Context, aggregate *aggregatestore.Aggregate[E], _ aggregatestore.HydrateOptions) error {
 	if aggregate != nil && s.hydratedAggregate != nil {
 		*aggregate = *s.hydratedAggregate
 	}
@@ -39,7 +39,7 @@ func (s *mockStore[E]) Hydrate(_ context.Context, aggregate *aggregatestore.Aggr
 	return s.hydrateErr
 }
 
-func (s *mockStore[E]) Save(_ context.Context, aggregate *aggregatestore.Aggregate[E], opts aggregatestore.SaveOptions) error {
+func (s *mockStore[E]) Save(_ context.Context, aggregate *aggregatestore.Aggregate[E], _ aggregatestore.SaveOptions) error {
 	if aggregate != nil && s.savedAggregate != nil {
 		*aggregate = *s.savedAggregate
 	}

--- a/aggregatestore/event_sourced_store.go
+++ b/aggregatestore/event_sourced_store.go
@@ -108,11 +108,12 @@ func (s *EventSourcedStore[E]) Load(ctx context.Context, id typeid.UUID, opts Lo
 
 // Hydrate hydrates an aggregate.
 func (s *EventSourcedStore[E]) Hydrate(ctx context.Context, aggregate *Aggregate[E], opts HydrateOptions) error {
-	if aggregate == nil {
+	switch {
+	case aggregate == nil:
 		return HydrateAggregateError{Err: errors.New("aggregate is nil")}
-	} else if opts.ToVersion < 0 {
+	case opts.ToVersion < 0:
 		return HydrateAggregateError{AggregateID: aggregate.ID(), Err: errors.New("invalid target version")}
-	} else if s.eventReader == nil {
+	case s.eventReader == nil:
 		return HydrateAggregateError{AggregateID: aggregate.ID(), Err: errors.New("event store has no event stream reader")}
 	}
 

--- a/aggregatestore/event_sourced_store.go
+++ b/aggregatestore/event_sourced_store.go
@@ -50,7 +50,7 @@ func NewEventSourcedStore[E estoria.Entity](
 		if _, ok := store.entityEventPrototypes[prototype.EventType()]; ok {
 			return nil, InitializeAggregateStoreError{
 				Operation: "registering entity event prototype",
-				Err: fmt.Errorf("duplicate event type %s for entity %T",
+				Err: fmt.Errorf("duplicate event type %s for entity %s",
 					prototype.EventType(),
 					entity.EntityID().TypeName()),
 			}
@@ -75,6 +75,10 @@ func NewEventSourcedStore[E estoria.Entity](
 // New creates a new aggregate.
 // If an ID is provided, the aggregate is created with that ID.
 func (s *EventSourcedStore[E]) New(id uuid.UUID) (*Aggregate[E], error) {
+	if id.IsNil() {
+		return nil, CreateAggregateError{Err: errors.New("aggregate ID is nil")}
+	}
+
 	aggregate := &Aggregate[E]{}
 	aggregate.State().SetEntityAtVersion(s.newEntity(id), 0)
 
@@ -161,7 +165,7 @@ func (s *EventSourcedStore[E]) Hydrate(ctx context.Context, aggregate *Aggregate
 			return HydrateAggregateError{
 				AggregateID: aggregate.ID(),
 				Operation:   "obtaining entity prototype",
-				Err:         errors.New("no prototype registered for event type %s" + event.ID.TypeName()),
+				Err:         errors.New("no prototype registered for event type " + event.ID.TypeName()),
 			}
 		}
 

--- a/aggregatestore/event_sourced_store.go
+++ b/aggregatestore/event_sourced_store.go
@@ -193,7 +193,7 @@ func (s *EventSourcedStore[E]) Save(ctx context.Context, aggregate *Aggregate[E]
 		return nil
 	}
 
-	events := make([]*eventstore.Event, len(unsavedEvents))
+	events := make([]*eventstore.WritableEvent, len(unsavedEvents))
 
 	for i, unsavedEvent := range unsavedEvents {
 		nextVersion := aggregate.Version() + int64(i) + 1
@@ -206,12 +206,9 @@ func (s *EventSourcedStore[E]) Save(ctx context.Context, aggregate *Aggregate[E]
 			return fmt.Errorf("serializing event data: %w", err)
 		}
 
-		events[i] = &eventstore.Event{
-			ID:            unsavedEvent.ID,
-			StreamID:      aggregate.ID(),
-			StreamVersion: nextVersion,
-			Timestamp:     unsavedEvent.Timestamp,
-			Data:          data,
+		events[i] = &eventstore.WritableEvent{
+			ID:   unsavedEvent.ID,
+			Data: data,
 		}
 	}
 

--- a/aggregatestore/event_sourced_store.go
+++ b/aggregatestore/event_sourced_store.go
@@ -132,7 +132,7 @@ func (s *EventSourcedStore[E]) Hydrate(ctx context.Context, aggregate *Aggregate
 
 	// load the aggregate's events
 	stream, err := s.eventReader.ReadStream(ctx, aggregate.ID(), readOpts)
-	if errors.Is(err, eventstore.ErrStreamNotFound) {
+	if errors.Is(err, eventstore.StreamNotFoundError{}) {
 		return ErrAggregateNotFound
 	} else if err != nil {
 		return fmt.Errorf("reading event stream: %w", err)

--- a/aggregatestore/event_sourced_store_test.go
+++ b/aggregatestore/event_sourced_store_test.go
@@ -476,7 +476,75 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 	for _, tt := range []struct {
 		name string
 	}{
-		{},
+		{
+			name: "hydrates an aggregate from version 0 to the latest version using default options",
+		},
+		{
+			name: "hydrates an aggregate from version 0 to a specific version",
+		},
+		{
+			name: "hydrates an aggregate from version 0 to version 1",
+		},
+		{
+			name: "hydrates an aggregate from version 0 to version N-1",
+		},
+		{
+			name: "hydrates an aggregate from version 1 to the latest version using default options",
+		},
+		{
+			name: "hydrates an aggregate from version 1 to a specific version",
+		},
+		{
+			name: "hydrates an aggregate from version 1 to version 2",
+		},
+		{
+			name: "hydrates an aggregate from version 1 to version N-1",
+		},
+		{
+			name: "hydrates an aggregate from a specific version to the latest version using default options",
+		},
+		{
+			name: "hydrates an aggregate from a specific version to another specific version",
+		},
+		{
+			name: "hydrates an aggregate from a specific version to version N-1",
+		},
+		{
+			name: "hydrates an aggregate from version N-1 to the latest version using default options",
+		},
+		{
+			name: "is a no-op when the aggregate is already at the target version",
+		},
+		{
+			name: "returns an error when the event stream reader is nil",
+		},
+		{
+			name: "returns an error when the aggregate is nil",
+		},
+		{
+			name: "returns an error when the target version is invalid",
+		},
+		{
+			name: "returns an error when the aggregate is at a more recent version than the target version",
+		},
+		{
+			name: "returns an error when the event stream is not found",
+		},
+		{
+			name: "returns an error when unable to obtain an event stream iterator",
+		},
+		{
+			name: "returns an error when unable to read an event from the event stream",
+		},
+		{
+			name: "returns an error when encountering an unregistered event type",
+		},
+		{
+			name: "returns an error when unable to unmarshal an event store event",
+		},
+		{
+			name: "returns an error when unable to apply an event to the aggregate",
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 

--- a/aggregatestore/event_sourced_store_test.go
+++ b/aggregatestore/event_sourced_store_test.go
@@ -1,0 +1,497 @@
+package aggregatestore_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/go-estoria/estoria"
+	"github.com/go-estoria/estoria/aggregatestore"
+	"github.com/go-estoria/estoria/eventstore"
+	"github.com/go-estoria/estoria/eventstore/memory"
+	"github.com/go-estoria/estoria/typeid"
+	"github.com/gofrs/uuid/v5"
+)
+
+type eventSourcedStoreTestCase[E estoria.Entity] struct {
+	name              string
+	haveEventStore    func() eventstore.Store
+	haveEntityFactory estoria.EntityFactory[E]
+	haveOpts          []aggregatestore.EventSourcedStoreOption[E]
+	wantErr           error
+}
+
+type mockEntity struct {
+	ID         typeid.UUID
+	eventTypes []estoria.EntityEvent
+
+	EventTypeAApplied bool
+	EventTypeBApplied bool
+	EventTypeCApplied bool
+}
+
+var _ estoria.Entity = &mockEntity{}
+
+func (e mockEntity) EntityID() typeid.UUID {
+	return e.ID
+}
+
+func (e mockEntity) EventTypes() []estoria.EntityEvent {
+	return e.eventTypes
+}
+
+func (e *mockEntity) ApplyEvent(_ context.Context, event estoria.EntityEvent) error {
+	switch event.EventType() {
+	case "mockEntityEventA":
+		e.EventTypeAApplied = true
+	case "mockEntityEventB":
+		e.EventTypeBApplied = true
+	case "mockEntityEventC":
+		e.EventTypeCApplied = true
+	default:
+		return errors.New("unknown event type")
+	}
+
+	return nil
+}
+
+type mockEntityEventA struct{}
+
+func (e mockEntityEventA) EventType() string {
+	return "mockEntityEventA"
+}
+
+func (e mockEntityEventA) New() estoria.EntityEvent {
+	return &mockEntityEventA{}
+}
+
+func (e mockEntityEventA) marshaledData() []byte {
+	b, _ := estoria.JSONMarshaler[mockEntityEventA]{}.Marshal(&e)
+	return b
+}
+
+type mockEntityEventB struct{}
+
+func (e mockEntityEventB) EventType() string {
+	return "mockEntityEventB"
+}
+
+func (e mockEntityEventB) New() estoria.EntityEvent {
+	return &mockEntityEventB{}
+}
+
+func (e mockEntityEventB) marshaledData() []byte {
+	b, _ := estoria.JSONMarshaler[mockEntityEventB]{}.Marshal(&e)
+	return b
+}
+
+type mockEntityEventC struct{}
+
+func (e mockEntityEventC) EventType() string {
+	return "mockEntityEventC"
+}
+
+func (e mockEntityEventC) New() estoria.EntityEvent {
+	return &mockEntityEventC{}
+}
+
+func (e mockEntityEventC) marshaledData() []byte {
+	b, _ := estoria.JSONMarshaler[mockEntityEventC]{}.Marshal(&e)
+	return b
+}
+
+type mockMarshaler struct{}
+
+func (m mockMarshaler) Marshal(_ *estoria.EntityEvent) ([]byte, error) {
+	return nil, nil
+}
+
+func (m mockMarshaler) Unmarshal(_ []byte, _ *estoria.EntityEvent) error {
+	return nil
+}
+
+func TestNewEventSourcedStore(t *testing.T) {
+	for _, tt := range []eventSourcedStoreTestCase[*mockEntity]{
+		{
+			name: "creates a new event sourced store with default options",
+			haveEventStore: func() eventstore.Store {
+				store, _ := memory.NewEventStore()
+				return store
+			},
+			haveEntityFactory: func(id uuid.UUID) *mockEntity {
+				return &mockEntity{ID: typeid.FromUUID("testentity", id)}
+			},
+		},
+		{
+			name: "creates a new event sourced store with default options and registers entity event prototypes",
+			haveEventStore: func() eventstore.Store {
+				store, _ := memory.NewEventStore()
+				return store
+			},
+			haveEntityFactory: func(id uuid.UUID) *mockEntity {
+				return &mockEntity{
+					ID: typeid.FromUUID("testentity", id),
+					eventTypes: []estoria.EntityEvent{
+						mockEntityEventA{},
+						mockEntityEventB{},
+						mockEntityEventC{},
+					},
+				}
+			},
+		},
+		{
+			name: "creates a new event sourced store with a custom entity event marshaler",
+			haveEventStore: func() eventstore.Store {
+				store, _ := memory.NewEventStore()
+				return store
+			},
+			haveEntityFactory: func(id uuid.UUID) *mockEntity {
+				return &mockEntity{ID: typeid.FromUUID("testentity", id)}
+			},
+			haveOpts: []aggregatestore.EventSourcedStoreOption[*mockEntity]{
+				aggregatestore.WithEntityEventMarshaler[*mockEntity](mockMarshaler{}),
+			},
+		},
+		{
+			name: "creates a new event sourced store with a custom stream reader",
+			haveEventStore: func() eventstore.Store {
+				store, _ := memory.NewEventStore()
+				return store
+			},
+			haveEntityFactory: func(id uuid.UUID) *mockEntity {
+				return &mockEntity{ID: typeid.FromUUID("testentity", id)}
+			},
+			haveOpts: []aggregatestore.EventSourcedStoreOption[*mockEntity]{
+				aggregatestore.WithStreamReader[*mockEntity](func() eventstore.Store {
+					store, _ := memory.NewEventStore()
+					return store
+				}()),
+			},
+		},
+		{
+			name: "creates a new event sourced store with a custom stream writer",
+			haveEventStore: func() eventstore.Store {
+				store, _ := memory.NewEventStore()
+				return store
+			},
+			haveEntityFactory: func(id uuid.UUID) *mockEntity {
+				return &mockEntity{ID: typeid.FromUUID("testentity", id)}
+			},
+			haveOpts: []aggregatestore.EventSourcedStoreOption[*mockEntity]{
+				aggregatestore.WithStreamWriter[*mockEntity](func() eventstore.Store {
+					store, _ := memory.NewEventStore()
+					return store
+				}()),
+			},
+		},
+		// {
+		// 	name: "returns an error when no event store is provided",
+		// 	haveEntityFactory: func(id uuid.UUID) *mockEntity {
+		// 		return &mockEntity{id: typeid.FromUUID("testentity", id)}
+		// 	},
+		// 	wantErr: aggregatestore.InitializeAggregateStoreError{
+		// 		Err: errors.New("no event stream reader or writer provided"),
+		// 	},
+		// },
+		{
+			name: "returns an error when a duplicate entity event prototype is registered",
+			haveEventStore: func() eventstore.Store {
+				store, _ := memory.NewEventStore()
+				return store
+			},
+			haveEntityFactory: func(id uuid.UUID) *mockEntity {
+				return &mockEntity{
+					ID: typeid.FromUUID("testentity", id),
+					eventTypes: []estoria.EntityEvent{
+						mockEntityEventA{},
+						mockEntityEventB{},
+						mockEntityEventA{},
+					},
+				}
+			},
+			wantErr: aggregatestore.InitializeAggregateStoreError{
+				Operation: "registering entity event prototype",
+				Err:       errors.New("duplicate event type mockEntityEventA for entity testentity"),
+			},
+		},
+		{
+			name: "returns an error when applying an option fails",
+			haveEventStore: func() eventstore.Store {
+				store, _ := memory.NewEventStore()
+				return store
+			},
+			haveEntityFactory: func(id uuid.UUID) *mockEntity {
+				return &mockEntity{ID: typeid.FromUUID("testentity", id)}
+			},
+			haveOpts: []aggregatestore.EventSourcedStoreOption[*mockEntity]{
+				func(store *aggregatestore.EventSourcedStore[*mockEntity]) error {
+					return errors.New("test error")
+				},
+			},
+			wantErr: aggregatestore.InitializeAggregateStoreError{
+				Operation: "applying option",
+				Err:       errors.New("test error"),
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			gotStore, err := aggregatestore.NewEventSourcedStore(tt.haveEventStore(), tt.haveEntityFactory, tt.haveOpts...)
+
+			if tt.wantErr != nil {
+				if err == nil || err.Error() != tt.wantErr.Error() {
+					t.Errorf("want error: %v, got: %v", tt.wantErr, err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error %v", err)
+			} else if gotStore == nil {
+				t.Errorf("unexpected nil store")
+			}
+		})
+	}
+}
+
+func TestEventSourcedStore_New(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		haveUUID uuid.UUID
+		wantErr  error
+	}{
+		{
+			name:     "creates a new aggregate with the provided ID",
+			haveUUID: uuid.Must(uuid.NewV4()),
+		},
+		{
+			name:     "returns an error when provided a nil aggregate ID",
+			haveUUID: uuid.Nil,
+			wantErr:  aggregatestore.CreateAggregateError{Err: errors.New("aggregate ID is nil")},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			store, err := aggregatestore.NewEventSourcedStore(
+				func() eventstore.Store {
+					store, _ := memory.NewEventStore()
+					return store
+				}(),
+				func(id uuid.UUID) *mockEntity {
+					return &mockEntity{ID: typeid.FromUUID("testentity", id)}
+				})
+			if err != nil {
+				t.Errorf("unexpected error creating store: %v", err)
+			}
+
+			gotAggregate, err := store.New(tt.haveUUID)
+
+			if tt.wantErr != nil {
+				if err == nil || err.Error() != tt.wantErr.Error() {
+					t.Errorf("want error: %v, got: %v", tt.wantErr, err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			} else if gotAggregate == nil {
+				t.Errorf("unexpected nil aggregate")
+			}
+
+			// aggregate has the correct ID
+			if gotAggregate.ID().String() != typeid.FromUUID("testentity", tt.haveUUID).String() {
+				t.Errorf("want entity ID %s, got %s", typeid.FromUUID("testentity", tt.haveUUID), gotAggregate.ID())
+			}
+
+			// aggregate has initial version 0
+			if gotAggregate.Version() != 0 {
+				t.Errorf("want entity version 0, got %d", gotAggregate.Version())
+			}
+		})
+	}
+}
+
+func TestEventSourcedStore_LoadAggregate(t *testing.T) {
+	aggregateID := typeid.Must(typeid.NewUUID("mockentity")).(typeid.UUID)
+	for _, tt := range []struct {
+		name              string
+		haveEventStore    func() eventstore.Store
+		haveEntityFactory func(id uuid.UUID) *mockEntity
+		haveAggregateID   typeid.UUID
+		haveOpts          aggregatestore.LoadOptions
+		wantVersion       int64
+		wantEntity        *mockEntity
+		wantErr           error
+	}{
+		{
+			name:            "loads an aggregate by its ID using default options",
+			haveAggregateID: aggregateID,
+			haveEventStore: func() eventstore.Store {
+				store, _ := memory.NewEventStore()
+				store.AppendStream(context.Background(), aggregateID, []*eventstore.WritableEvent{
+					{ID: typeid.Must(typeid.NewUUID("mockEntityEventA")).(typeid.UUID), Data: mockEntityEventA{}.marshaledData()},
+					{ID: typeid.Must(typeid.NewUUID("mockEntityEventB")).(typeid.UUID), Data: mockEntityEventB{}.marshaledData()},
+					{ID: typeid.Must(typeid.NewUUID("mockEntityEventC")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
+				}, eventstore.AppendStreamOptions{})
+				return store
+			},
+			haveEntityFactory: func(id uuid.UUID) *mockEntity {
+				return &mockEntity{
+					ID: typeid.FromUUID("mockentity", id),
+					eventTypes: []estoria.EntityEvent{
+						mockEntityEventA{},
+						mockEntityEventB{},
+						mockEntityEventC{},
+					},
+				}
+			},
+			wantVersion: 3,
+			wantEntity: &mockEntity{
+				ID:                aggregateID,
+				EventTypeAApplied: true,
+				EventTypeBApplied: true,
+				EventTypeCApplied: true,
+			},
+		},
+		{
+			name:            "loads an aggregate to a specific version by its ID ",
+			haveAggregateID: aggregateID,
+			haveEventStore: func() eventstore.Store {
+				store, _ := memory.NewEventStore()
+				store.AppendStream(context.Background(), aggregateID, []*eventstore.WritableEvent{
+					{ID: typeid.Must(typeid.NewUUID("mockEntityEventA")).(typeid.UUID), Data: mockEntityEventA{}.marshaledData()},
+					{ID: typeid.Must(typeid.NewUUID("mockEntityEventB")).(typeid.UUID), Data: mockEntityEventB{}.marshaledData()},
+					{ID: typeid.Must(typeid.NewUUID("mockEntityEventC")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
+				}, eventstore.AppendStreamOptions{})
+				return store
+			},
+			haveEntityFactory: func(id uuid.UUID) *mockEntity {
+				return &mockEntity{
+					ID: typeid.FromUUID("mockentity", id),
+					eventTypes: []estoria.EntityEvent{
+						mockEntityEventA{},
+						mockEntityEventB{},
+						mockEntityEventC{},
+					},
+				}
+			},
+			haveOpts:    aggregatestore.LoadOptions{ToVersion: 2},
+			wantVersion: 2,
+			wantEntity: &mockEntity{
+				ID:                aggregateID,
+				EventTypeAApplied: true,
+				EventTypeBApplied: true,
+				EventTypeCApplied: false,
+			},
+		},
+		{
+			name:            "returns an error when the aggregate ID is nil",
+			haveAggregateID: typeid.FromUUID("mockentity", uuid.Nil),
+			haveEventStore: func() eventstore.Store {
+				store, _ := memory.NewEventStore()
+				return store
+			},
+			haveEntityFactory: func(id uuid.UUID) *mockEntity {
+				return &mockEntity{
+					ID: typeid.FromUUID("mockentity", id),
+					eventTypes: []estoria.EntityEvent{
+						mockEntityEventA{},
+						mockEntityEventB{},
+						mockEntityEventC{},
+					},
+				}
+			},
+			wantErr: errors.New("creating new aggregate: aggregate ID is nil"),
+		},
+		{
+			name:            "returns an error when the aggregate cannot be hydrated",
+			haveAggregateID: aggregateID,
+			haveEventStore: func() eventstore.Store {
+				store, _ := memory.NewEventStore()
+				return store
+			},
+			haveEntityFactory: func(id uuid.UUID) *mockEntity {
+				return &mockEntity{
+					ID: typeid.FromUUID("mockentity", id),
+					eventTypes: []estoria.EntityEvent{
+						mockEntityEventA{},
+						mockEntityEventB{},
+						mockEntityEventC{},
+					},
+				}
+			},
+			wantErr: errors.New("hydrating aggregate: reading event stream: stream not found: " + aggregateID.String()),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			store, err := aggregatestore.NewEventSourcedStore(tt.haveEventStore(), tt.haveEntityFactory)
+			if err != nil {
+				t.Errorf("unexpected error creating store: %v", err)
+			}
+
+			gotAggregate, err := store.Load(context.Background(), tt.haveAggregateID, tt.haveOpts)
+
+			if tt.wantErr != nil {
+				if err == nil || err.Error() != tt.wantErr.Error() {
+					t.Errorf("want error: %v, got: %v", tt.wantErr, err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			} else if gotAggregate == nil {
+				t.Errorf("unexpected nil aggregate")
+			}
+
+			// aggregate has the correct ID
+			if gotAggregate.ID().String() != typeid.FromUUID("mockentity", tt.haveAggregateID.UUID()).String() {
+				t.Errorf("want aggregate ID %s, got %s", typeid.FromUUID("mockentity", tt.haveAggregateID.UUID()), gotAggregate.ID())
+			}
+			// aggregate has the correct version
+			if gotAggregate.Version() != tt.wantVersion {
+				t.Errorf("want aggregate version %d, got %d", tt.wantVersion, gotAggregate.Version())
+			}
+			// aggregate has the correct entity
+			gotEntity := gotAggregate.Entity()
+			if gotEntity == nil {
+				t.Errorf("unexpected nil entity")
+			}
+			if gotEntity.ID.String() != tt.haveAggregateID.String() {
+				t.Errorf("want entity ID %s, got %s", tt.haveAggregateID, gotEntity.ID)
+			}
+			if gotEntity.EventTypeAApplied != tt.wantEntity.EventTypeAApplied {
+				t.Errorf("want EventTypeAApplied %v, got %v", tt.wantEntity.EventTypeAApplied, gotEntity.EventTypeAApplied)
+			}
+			if gotEntity.EventTypeBApplied != tt.wantEntity.EventTypeBApplied {
+				t.Errorf("want EventTypeBApplied %v, got %v", tt.wantEntity.EventTypeBApplied, gotEntity.EventTypeBApplied)
+			}
+			if gotEntity.EventTypeCApplied != tt.wantEntity.EventTypeCApplied {
+				t.Errorf("want EventTypeCApplied %v, got %v", tt.wantEntity.EventTypeCApplied, gotEntity.EventTypeCApplied)
+			}
+		})
+	}
+}
+
+func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+	}{
+		{},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+
+		})
+	}
+}
+
+func TestEventSourcedStore_SaveAggregate(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+	}{
+		{},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+
+		})
+	}
+}

--- a/aggregatestore/event_sourced_store_test.go
+++ b/aggregatestore/event_sourced_store_test.go
@@ -40,7 +40,7 @@ func (e mockEntity) EventTypes() []estoria.EntityEvent {
 	return e.eventTypes
 }
 
-func (e *mockEntity) ApplyEvent(_ context.Context, event estoria.EntityEvent) error {
+func (e *mockEntity) ApplyEvent(_ context.Context, _ estoria.EntityEvent) error {
 	if e.applyEventErr != nil {
 		return e.applyEventErr
 	}
@@ -171,6 +171,8 @@ func (m mockStreamIterator) Close(_ context.Context) error {
 }
 
 func TestNewEventSourcedStore(t *testing.T) {
+	t.Parallel()
+
 	for _, tt := range []eventSourcedStoreTestCase[*mockEntity]{
 		{
 			name: "creates a new event sourced store with default options",
@@ -284,7 +286,7 @@ func TestNewEventSourcedStore(t *testing.T) {
 				return &mockEntity{ID: typeid.FromUUID("testentity", id)}
 			},
 			haveOpts: []aggregatestore.EventSourcedStoreOption[*mockEntity]{
-				func(store *aggregatestore.EventSourcedStore[*mockEntity]) error {
+				func(_ *aggregatestore.EventSourcedStore[*mockEntity]) error {
 					return errors.New("test error")
 				},
 			},
@@ -295,6 +297,8 @@ func TestNewEventSourcedStore(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			gotStore, err := aggregatestore.NewEventSourcedStore(tt.haveEventStore(), tt.haveEntityFactory, tt.haveOpts...)
 
 			if tt.wantErr != nil {
@@ -314,6 +318,8 @@ func TestNewEventSourcedStore(t *testing.T) {
 }
 
 func TestEventSourcedStore_New(t *testing.T) {
+	t.Parallel()
+
 	for _, tt := range []struct {
 		name     string
 		haveUUID uuid.UUID
@@ -330,6 +336,8 @@ func TestEventSourcedStore_New(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			store, err := aggregatestore.NewEventSourcedStore(
 				func() eventstore.Store {
 					store, _ := memory.NewEventStore()
@@ -371,6 +379,8 @@ func TestEventSourcedStore_New(t *testing.T) {
 }
 
 func TestEventSourcedStore_LoadAggregate(t *testing.T) {
+	t.Parallel()
+
 	aggregateID := typeid.Must(typeid.NewUUID("mockentity")).(typeid.UUID)
 	for _, tt := range []struct {
 		name              string
@@ -451,6 +461,8 @@ func TestEventSourcedStore_LoadAggregate(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			store, err := aggregatestore.NewEventSourcedStore(tt.haveEventStore(), tt.haveEntityFactory)
 			if err != nil {
 				t.Errorf("unexpected error creating store: %v", err)
@@ -483,6 +495,7 @@ func TestEventSourcedStore_LoadAggregate(t *testing.T) {
 			gotEntity := gotAggregate.Entity()
 			if gotEntity == nil {
 				t.Errorf("unexpected nil entity")
+				return
 			}
 			// entity has the correct ID
 			if gotEntity.ID.String() != tt.haveAggregateID.String() {
@@ -497,6 +510,8 @@ func TestEventSourcedStore_LoadAggregate(t *testing.T) {
 }
 
 func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
+	t.Parallel()
+
 	aggregateID := typeid.Must(typeid.NewUUID("mockentity")).(typeid.UUID)
 	for _, tt := range []struct {
 		name              string
@@ -517,8 +532,8 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventA")).(typeid.UUID), Data: mockEntityEventA{}.marshaledData()},
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventB")).(typeid.UUID), Data: mockEntityEventB{}.marshaledData()},
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventC")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
-					{ID: typeid.Must(typeid.NewUUID("mockEntityEventD")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
-					{ID: typeid.Must(typeid.NewUUID("mockEntityEventE")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
+					{ID: typeid.Must(typeid.NewUUID("mockEntityEventD")).(typeid.UUID), Data: mockEntityEventD{}.marshaledData()},
+					{ID: typeid.Must(typeid.NewUUID("mockEntityEventE")).(typeid.UUID), Data: mockEntityEventE{}.marshaledData()},
 				}, eventstore.AppendStreamOptions{})
 				return store
 			},
@@ -545,8 +560,8 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventA")).(typeid.UUID), Data: mockEntityEventA{}.marshaledData()},
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventB")).(typeid.UUID), Data: mockEntityEventB{}.marshaledData()},
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventC")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
-					{ID: typeid.Must(typeid.NewUUID("mockEntityEventD")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
-					{ID: typeid.Must(typeid.NewUUID("mockEntityEventE")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
+					{ID: typeid.Must(typeid.NewUUID("mockEntityEventD")).(typeid.UUID), Data: mockEntityEventD{}.marshaledData()},
+					{ID: typeid.Must(typeid.NewUUID("mockEntityEventE")).(typeid.UUID), Data: mockEntityEventE{}.marshaledData()},
 				}, eventstore.AppendStreamOptions{})
 				return store
 			},
@@ -573,8 +588,8 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventA")).(typeid.UUID), Data: mockEntityEventA{}.marshaledData()},
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventB")).(typeid.UUID), Data: mockEntityEventB{}.marshaledData()},
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventC")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
-					{ID: typeid.Must(typeid.NewUUID("mockEntityEventD")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
-					{ID: typeid.Must(typeid.NewUUID("mockEntityEventE")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
+					{ID: typeid.Must(typeid.NewUUID("mockEntityEventD")).(typeid.UUID), Data: mockEntityEventD{}.marshaledData()},
+					{ID: typeid.Must(typeid.NewUUID("mockEntityEventE")).(typeid.UUID), Data: mockEntityEventE{}.marshaledData()},
 				}, eventstore.AppendStreamOptions{})
 				return store
 			},
@@ -601,8 +616,8 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventA")).(typeid.UUID), Data: mockEntityEventA{}.marshaledData()},
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventB")).(typeid.UUID), Data: mockEntityEventB{}.marshaledData()},
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventC")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
-					{ID: typeid.Must(typeid.NewUUID("mockEntityEventD")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
-					{ID: typeid.Must(typeid.NewUUID("mockEntityEventE")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
+					{ID: typeid.Must(typeid.NewUUID("mockEntityEventD")).(typeid.UUID), Data: mockEntityEventD{}.marshaledData()},
+					{ID: typeid.Must(typeid.NewUUID("mockEntityEventE")).(typeid.UUID), Data: mockEntityEventE{}.marshaledData()},
 				}, eventstore.AppendStreamOptions{})
 				return store
 			},
@@ -629,8 +644,8 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventA")).(typeid.UUID), Data: mockEntityEventA{}.marshaledData()},
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventB")).(typeid.UUID), Data: mockEntityEventB{}.marshaledData()},
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventC")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
-					{ID: typeid.Must(typeid.NewUUID("mockEntityEventD")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
-					{ID: typeid.Must(typeid.NewUUID("mockEntityEventE")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
+					{ID: typeid.Must(typeid.NewUUID("mockEntityEventD")).(typeid.UUID), Data: mockEntityEventD{}.marshaledData()},
+					{ID: typeid.Must(typeid.NewUUID("mockEntityEventE")).(typeid.UUID), Data: mockEntityEventE{}.marshaledData()},
 				}, eventstore.AppendStreamOptions{})
 				return store
 			},
@@ -657,8 +672,8 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventA")).(typeid.UUID), Data: mockEntityEventA{}.marshaledData()},
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventB")).(typeid.UUID), Data: mockEntityEventB{}.marshaledData()},
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventC")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
-					{ID: typeid.Must(typeid.NewUUID("mockEntityEventD")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
-					{ID: typeid.Must(typeid.NewUUID("mockEntityEventE")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
+					{ID: typeid.Must(typeid.NewUUID("mockEntityEventD")).(typeid.UUID), Data: mockEntityEventD{}.marshaledData()},
+					{ID: typeid.Must(typeid.NewUUID("mockEntityEventE")).(typeid.UUID), Data: mockEntityEventE{}.marshaledData()},
 				}, eventstore.AppendStreamOptions{})
 				return store
 			},
@@ -685,8 +700,8 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventA")).(typeid.UUID), Data: mockEntityEventA{}.marshaledData()},
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventB")).(typeid.UUID), Data: mockEntityEventB{}.marshaledData()},
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventC")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
-					{ID: typeid.Must(typeid.NewUUID("mockEntityEventD")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
-					{ID: typeid.Must(typeid.NewUUID("mockEntityEventE")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
+					{ID: typeid.Must(typeid.NewUUID("mockEntityEventD")).(typeid.UUID), Data: mockEntityEventD{}.marshaledData()},
+					{ID: typeid.Must(typeid.NewUUID("mockEntityEventE")).(typeid.UUID), Data: mockEntityEventE{}.marshaledData()},
 				}, eventstore.AppendStreamOptions{})
 				return store
 			},
@@ -713,8 +728,8 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventA")).(typeid.UUID), Data: mockEntityEventA{}.marshaledData()},
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventB")).(typeid.UUID), Data: mockEntityEventB{}.marshaledData()},
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventC")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
-					{ID: typeid.Must(typeid.NewUUID("mockEntityEventD")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
-					{ID: typeid.Must(typeid.NewUUID("mockEntityEventE")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
+					{ID: typeid.Must(typeid.NewUUID("mockEntityEventD")).(typeid.UUID), Data: mockEntityEventD{}.marshaledData()},
+					{ID: typeid.Must(typeid.NewUUID("mockEntityEventE")).(typeid.UUID), Data: mockEntityEventE{}.marshaledData()},
 				}, eventstore.AppendStreamOptions{})
 				return store
 			},
@@ -741,8 +756,8 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventA")).(typeid.UUID), Data: mockEntityEventA{}.marshaledData()},
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventB")).(typeid.UUID), Data: mockEntityEventB{}.marshaledData()},
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventC")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
-					{ID: typeid.Must(typeid.NewUUID("mockEntityEventD")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
-					{ID: typeid.Must(typeid.NewUUID("mockEntityEventE")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
+					{ID: typeid.Must(typeid.NewUUID("mockEntityEventD")).(typeid.UUID), Data: mockEntityEventD{}.marshaledData()},
+					{ID: typeid.Must(typeid.NewUUID("mockEntityEventE")).(typeid.UUID), Data: mockEntityEventE{}.marshaledData()},
 				}, eventstore.AppendStreamOptions{})
 				return store
 			},
@@ -769,8 +784,8 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventA")).(typeid.UUID), Data: mockEntityEventA{}.marshaledData()},
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventB")).(typeid.UUID), Data: mockEntityEventB{}.marshaledData()},
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventC")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
-					{ID: typeid.Must(typeid.NewUUID("mockEntityEventD")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
-					{ID: typeid.Must(typeid.NewUUID("mockEntityEventE")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
+					{ID: typeid.Must(typeid.NewUUID("mockEntityEventD")).(typeid.UUID), Data: mockEntityEventD{}.marshaledData()},
+					{ID: typeid.Must(typeid.NewUUID("mockEntityEventE")).(typeid.UUID), Data: mockEntityEventE{}.marshaledData()},
 				}, eventstore.AppendStreamOptions{})
 				return store
 			},
@@ -797,8 +812,8 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventA")).(typeid.UUID), Data: mockEntityEventA{}.marshaledData()},
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventB")).(typeid.UUID), Data: mockEntityEventB{}.marshaledData()},
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventC")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
-					{ID: typeid.Must(typeid.NewUUID("mockEntityEventD")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
-					{ID: typeid.Must(typeid.NewUUID("mockEntityEventE")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
+					{ID: typeid.Must(typeid.NewUUID("mockEntityEventD")).(typeid.UUID), Data: mockEntityEventD{}.marshaledData()},
+					{ID: typeid.Must(typeid.NewUUID("mockEntityEventE")).(typeid.UUID), Data: mockEntityEventE{}.marshaledData()},
 				}, eventstore.AppendStreamOptions{})
 				return store
 			},
@@ -825,8 +840,8 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventA")).(typeid.UUID), Data: mockEntityEventA{}.marshaledData()},
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventB")).(typeid.UUID), Data: mockEntityEventB{}.marshaledData()},
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventC")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
-					{ID: typeid.Must(typeid.NewUUID("mockEntityEventD")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
-					{ID: typeid.Must(typeid.NewUUID("mockEntityEventE")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
+					{ID: typeid.Must(typeid.NewUUID("mockEntityEventD")).(typeid.UUID), Data: mockEntityEventD{}.marshaledData()},
+					{ID: typeid.Must(typeid.NewUUID("mockEntityEventE")).(typeid.UUID), Data: mockEntityEventE{}.marshaledData()},
 				}, eventstore.AppendStreamOptions{})
 				return store
 			},
@@ -853,8 +868,8 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventA")).(typeid.UUID), Data: mockEntityEventA{}.marshaledData()},
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventB")).(typeid.UUID), Data: mockEntityEventB{}.marshaledData()},
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventC")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
-					{ID: typeid.Must(typeid.NewUUID("mockEntityEventD")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
-					{ID: typeid.Must(typeid.NewUUID("mockEntityEventE")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
+					{ID: typeid.Must(typeid.NewUUID("mockEntityEventD")).(typeid.UUID), Data: mockEntityEventD{}.marshaledData()},
+					{ID: typeid.Must(typeid.NewUUID("mockEntityEventE")).(typeid.UUID), Data: mockEntityEventE{}.marshaledData()},
 				}, eventstore.AppendStreamOptions{})
 				return store
 			},
@@ -881,8 +896,8 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventA")).(typeid.UUID), Data: mockEntityEventA{}.marshaledData()},
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventB")).(typeid.UUID), Data: mockEntityEventB{}.marshaledData()},
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventC")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
-					{ID: typeid.Must(typeid.NewUUID("mockEntityEventD")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
-					{ID: typeid.Must(typeid.NewUUID("mockEntityEventE")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
+					{ID: typeid.Must(typeid.NewUUID("mockEntityEventD")).(typeid.UUID), Data: mockEntityEventD{}.marshaledData()},
+					{ID: typeid.Must(typeid.NewUUID("mockEntityEventE")).(typeid.UUID), Data: mockEntityEventE{}.marshaledData()},
 				}, eventstore.AppendStreamOptions{})
 				return store
 			},
@@ -973,8 +988,8 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventA")).(typeid.UUID), Data: mockEntityEventA{}.marshaledData()},
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventB")).(typeid.UUID), Data: mockEntityEventB{}.marshaledData()},
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventC")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
-					{ID: typeid.Must(typeid.NewUUID("mockEntityEventD")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
-					{ID: typeid.Must(typeid.NewUUID("mockEntityEventE")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
+					{ID: typeid.Must(typeid.NewUUID("mockEntityEventD")).(typeid.UUID), Data: mockEntityEventD{}.marshaledData()},
+					{ID: typeid.Must(typeid.NewUUID("mockEntityEventE")).(typeid.UUID), Data: mockEntityEventE{}.marshaledData()},
 				}, eventstore.AppendStreamOptions{})
 				return store
 			},
@@ -1002,8 +1017,8 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventA")).(typeid.UUID), Data: mockEntityEventA{}.marshaledData()},
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventB")).(typeid.UUID), Data: mockEntityEventB{}.marshaledData()},
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventC")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
-					{ID: typeid.Must(typeid.NewUUID("mockEntityEventD")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
-					{ID: typeid.Must(typeid.NewUUID("mockEntityEventE")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
+					{ID: typeid.Must(typeid.NewUUID("mockEntityEventD")).(typeid.UUID), Data: mockEntityEventD{}.marshaledData()},
+					{ID: typeid.Must(typeid.NewUUID("mockEntityEventE")).(typeid.UUID), Data: mockEntityEventE{}.marshaledData()},
 				}, eventstore.AppendStreamOptions{})
 				return store
 			},
@@ -1032,8 +1047,8 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventA")).(typeid.UUID), Data: mockEntityEventA{}.marshaledData()},
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventB")).(typeid.UUID), Data: mockEntityEventB{}.marshaledData()},
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventC")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
-					{ID: typeid.Must(typeid.NewUUID("mockEntityEventD")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
-					{ID: typeid.Must(typeid.NewUUID("mockEntityEventE")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
+					{ID: typeid.Must(typeid.NewUUID("mockEntityEventD")).(typeid.UUID), Data: mockEntityEventD{}.marshaledData()},
+					{ID: typeid.Must(typeid.NewUUID("mockEntityEventE")).(typeid.UUID), Data: mockEntityEventE{}.marshaledData()},
 				}, eventstore.AppendStreamOptions{})
 				return store
 			},
@@ -1055,8 +1070,8 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventA")).(typeid.UUID), Data: mockEntityEventA{}.marshaledData()},
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventB")).(typeid.UUID), Data: mockEntityEventB{}.marshaledData()},
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventC")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
-					{ID: typeid.Must(typeid.NewUUID("mockEntityEventD")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
-					{ID: typeid.Must(typeid.NewUUID("mockEntityEventE")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
+					{ID: typeid.Must(typeid.NewUUID("mockEntityEventD")).(typeid.UUID), Data: mockEntityEventD{}.marshaledData()},
+					{ID: typeid.Must(typeid.NewUUID("mockEntityEventE")).(typeid.UUID), Data: mockEntityEventE{}.marshaledData()},
 				}, eventstore.AppendStreamOptions{})
 				return store
 			},
@@ -1083,8 +1098,8 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventA")).(typeid.UUID), Data: mockEntityEventA{}.marshaledData()},
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventB")).(typeid.UUID), Data: mockEntityEventB{}.marshaledData()},
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventC")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
-					{ID: typeid.Must(typeid.NewUUID("mockEntityEventD")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
-					{ID: typeid.Must(typeid.NewUUID("mockEntityEventE")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
+					{ID: typeid.Must(typeid.NewUUID("mockEntityEventD")).(typeid.UUID), Data: mockEntityEventD{}.marshaledData()},
+					{ID: typeid.Must(typeid.NewUUID("mockEntityEventE")).(typeid.UUID), Data: mockEntityEventE{}.marshaledData()},
 				}, eventstore.AppendStreamOptions{})
 				return store
 			},
@@ -1112,8 +1127,8 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventA")).(typeid.UUID), Data: mockEntityEventA{}.marshaledData()},
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventB")).(typeid.UUID), Data: mockEntityEventB{}.marshaledData()},
 					{ID: typeid.Must(typeid.NewUUID("mockEntityEventC")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
-					{ID: typeid.Must(typeid.NewUUID("mockEntityEventD")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
-					{ID: typeid.Must(typeid.NewUUID("mockEntityEventE")).(typeid.UUID), Data: mockEntityEventC{}.marshaledData()},
+					{ID: typeid.Must(typeid.NewUUID("mockEntityEventD")).(typeid.UUID), Data: mockEntityEventD{}.marshaledData()},
+					{ID: typeid.Must(typeid.NewUUID("mockEntityEventE")).(typeid.UUID), Data: mockEntityEventE{}.marshaledData()},
 				}, eventstore.AppendStreamOptions{})
 				return store
 			},
@@ -1135,6 +1150,8 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			store, err := aggregatestore.NewEventSourcedStore(tt.haveEventStore(), tt.haveEntityFactory, tt.haveStoreOpts...)
 			if err != nil {
 				t.Errorf("unexpected error creating store: %v", err)
@@ -1171,6 +1188,7 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 			gotEntity := aggregate.Entity()
 			if gotEntity == nil {
 				t.Errorf("unexpected nil entity")
+				return
 			}
 			// entity has the correct ID
 			if gotEntity.ID.String() != tt.wantEntity.ID.String() {
@@ -1185,6 +1203,8 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 }
 
 func TestEventSourcedStore_SaveAggregate(t *testing.T) {
+	t.Parallel()
+
 	aggregateID := typeid.Must(typeid.NewUUID("mockentity")).(typeid.UUID)
 	for _, tt := range []struct {
 		name              string
@@ -1575,6 +1595,8 @@ func TestEventSourcedStore_SaveAggregate(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			store, err := aggregatestore.NewEventSourcedStore(tt.haveEventStore(), tt.haveEntityFactory, tt.haveStoreOpts...)
 			if err != nil {
 				t.Errorf("unexpected error creating store: %v", err)
@@ -1611,6 +1633,7 @@ func TestEventSourcedStore_SaveAggregate(t *testing.T) {
 			gotEntity := aggregate.Entity()
 			if gotEntity == nil {
 				t.Errorf("unexpected nil entity")
+				return
 			}
 			// entity has the correct ID
 			if gotEntity.ID.String() != tt.wantEntity.ID.String() {

--- a/aggregatestore/snapshotting_store.go
+++ b/aggregatestore/snapshotting_store.go
@@ -53,7 +53,7 @@ func NewSnapshottingStore[E estoria.Entity](
 	store SnapshotStore,
 	policy SnapshotPolicy,
 	opts ...SnapshottingStoreOption[E],
-) *SnapshottingStore[E] {
+) (*SnapshottingStore[E], error) {
 	aggregateStore := &SnapshottingStore[E]{
 		inner:     inner,
 		reader:    store,
@@ -64,10 +64,12 @@ func NewSnapshottingStore[E estoria.Entity](
 	}
 
 	for _, opt := range opts {
-		opt(aggregateStore)
+		if err := opt(aggregateStore); err != nil {
+			return nil, fmt.Errorf("applying option: %w", err)
+		}
 	}
 
-	return aggregateStore
+	return aggregateStore, nil
 }
 
 // NewAggregate creates a new aggregate.

--- a/aggregatestore/snapshotting_store.go
+++ b/aggregatestore/snapshotting_store.go
@@ -54,6 +54,15 @@ func NewSnapshottingStore[E estoria.Entity](
 	policy SnapshotPolicy,
 	opts ...SnapshottingStoreOption[E],
 ) (*SnapshottingStore[E], error) {
+	switch {
+	case inner == nil:
+		return nil, InitializeAggregateStoreError{Err: errors.New("inner store is required")}
+	case store == nil:
+		return nil, InitializeAggregateStoreError{Err: errors.New("snapshot store is required")}
+	case policy == nil:
+		return nil, InitializeAggregateStoreError{Err: errors.New("snapshot policy is required")}
+	}
+
 	aggregateStore := &SnapshottingStore[E]{
 		inner:     inner,
 		reader:    store,
@@ -65,7 +74,7 @@ func NewSnapshottingStore[E estoria.Entity](
 
 	for _, opt := range opts {
 		if err := opt(aggregateStore); err != nil {
-			return nil, fmt.Errorf("applying option: %w", err)
+			return nil, InitializeAggregateStoreError{Operation: "applying option", Err: err}
 		}
 	}
 
@@ -98,12 +107,32 @@ func (s *SnapshottingStore[E]) Load(ctx context.Context, aggregateID typeid.UUID
 
 // Hydrate hydrates an aggregate.
 func (s *SnapshottingStore[E]) Hydrate(ctx context.Context, aggregate *Aggregate[E], opts HydrateOptions) error {
+	switch {
+	case aggregate == nil:
+		return HydrateAggregateError{Err: errors.New("aggregate is nil")}
+	case opts.ToVersion < 0:
+		return HydrateAggregateError{AggregateID: aggregate.ID(), Err: errors.New("invalid target version")}
+	case s.reader == nil:
+		return HydrateAggregateError{AggregateID: aggregate.ID(), Err: errors.New("snapshot store has no snapshot reader")}
+	}
+
 	log := s.log.With("aggregate_id", aggregate.ID())
 	log.Debug("hydrating aggregate from snapshot", "from_version", aggregate.Version(), "to_version", opts.ToVersion)
 
-	snap, err := s.reader.ReadSnapshot(ctx, aggregate.ID(), snapshotstore.ReadSnapshotOptions{
-		MaxVersion: opts.ToVersion,
-	})
+	readSnapshotOpts := snapshotstore.ReadSnapshotOptions{}
+	if opts.ToVersion > 0 {
+		if v := aggregate.Version(); v == opts.ToVersion {
+			log.Debug("aggregate already at target version, nothing to hydrate", "version", opts.ToVersion)
+			return s.inner.Hydrate(ctx, aggregate, opts)
+		} else if v > opts.ToVersion {
+			log.Debug("aggregate version is higher than target version, nothing to hydrate", "version", v, "target_version", opts.ToVersion)
+			return s.inner.Hydrate(ctx, aggregate, opts)
+		}
+
+		readSnapshotOpts.MaxVersion = opts.ToVersion
+	}
+
+	snap, err := s.reader.ReadSnapshot(ctx, aggregate.ID(), readSnapshotOpts)
 	if err != nil {
 		slog.Warn("failed to read snapshot", "error", err)
 		return s.inner.Hydrate(ctx, aggregate, opts)

--- a/aggregatestore/snapshotting_store.go
+++ b/aggregatestore/snapshotting_store.go
@@ -141,6 +141,7 @@ func (s *SnapshottingStore[E]) Save(ctx context.Context, aggregate *Aggregate[E]
 	}
 
 	now := time.Now()
+
 	for {
 		err := aggregate.State().ApplyNext(ctx)
 		if errors.Is(err, ErrNoUnappliedEvents) {
@@ -151,7 +152,9 @@ func (s *SnapshottingStore[E]) Save(ctx context.Context, aggregate *Aggregate[E]
 
 		if s.policy.ShouldSnapshot(aggregate.ID(), aggregate.Version(), now) {
 			slog.Debug("taking snapshot", "aggregate_id", aggregate.ID(), "version", aggregate.Version())
+
 			entity := aggregate.Entity()
+
 			data, err := s.marshaler.Marshal(&entity)
 			if err != nil {
 				slog.Error("failed to marshal snapshot", "error", err)

--- a/aggregatestore/snapshotting_store_test.go
+++ b/aggregatestore/snapshotting_store_test.go
@@ -1,0 +1,828 @@
+package aggregatestore_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/go-estoria/estoria"
+	"github.com/go-estoria/estoria/aggregatestore"
+	"github.com/go-estoria/estoria/snapshotstore"
+	"github.com/go-estoria/estoria/typeid"
+	"github.com/gofrs/uuid/v5"
+)
+
+type mockStore2[E estoria.Entity] struct {
+	NewFn     func(id uuid.UUID) (*aggregatestore.Aggregate[E], error)
+	LoadFn    func(context.Context, typeid.UUID, aggregatestore.LoadOptions) (*aggregatestore.Aggregate[E], error)
+	HydrateFn func(context.Context, *aggregatestore.Aggregate[E], aggregatestore.HydrateOptions) error
+	SaveFn    func(context.Context, *aggregatestore.Aggregate[E], aggregatestore.SaveOptions) error
+}
+
+func (s *mockStore2[E]) New(id uuid.UUID) (*aggregatestore.Aggregate[E], error) {
+	if s.NewFn != nil {
+		return s.NewFn(id)
+	}
+
+	return nil, fmt.Errorf("unexpected call: New(id=%s)", id.String())
+}
+
+func (s *mockStore2[E]) Load(ctx context.Context, aggregateID typeid.UUID, opts aggregatestore.LoadOptions) (*aggregatestore.Aggregate[E], error) {
+	if s.LoadFn != nil {
+		return s.LoadFn(ctx, aggregateID, opts)
+	}
+
+	return nil, fmt.Errorf("unexpected call: Load(aggregateID=%s, opts=%v)", aggregateID, opts)
+}
+
+func (s *mockStore2[E]) Hydrate(ctx context.Context, aggregate *aggregatestore.Aggregate[E], opts aggregatestore.HydrateOptions) error {
+	if s.HydrateFn != nil {
+		return s.HydrateFn(ctx, aggregate, opts)
+	}
+
+	return fmt.Errorf("unexpected call: Hydrate(aggregate=%v, opts=%v)", aggregate, opts)
+}
+
+func (s *mockStore2[E]) Save(ctx context.Context, aggregate *aggregatestore.Aggregate[E], opts aggregatestore.SaveOptions) error {
+	if s.SaveFn != nil {
+		return s.SaveFn(ctx, aggregate, opts)
+	}
+
+	return fmt.Errorf("unexpected call: Save(aggregate=%v, opts=%v)", aggregate, opts)
+}
+
+type mockSnapshotStore struct {
+	ReadSnapshotFn  func(context.Context, typeid.UUID, snapshotstore.ReadSnapshotOptions) (*snapshotstore.AggregateSnapshot, error)
+	WriteSnapshotFn func(context.Context, *snapshotstore.AggregateSnapshot) error
+}
+
+func (m *mockSnapshotStore) ReadSnapshot(ctx context.Context, aggregateID typeid.UUID, opts snapshotstore.ReadSnapshotOptions) (*snapshotstore.AggregateSnapshot, error) {
+	if m.ReadSnapshotFn != nil {
+		return m.ReadSnapshotFn(ctx, aggregateID, opts)
+	}
+
+	return nil, errors.New("unexpected call to ReadSnapshot")
+}
+
+func (m *mockSnapshotStore) WriteSnapshot(ctx context.Context, snapshot *snapshotstore.AggregateSnapshot) error {
+	if m.WriteSnapshotFn != nil {
+		return m.WriteSnapshotFn(ctx, snapshot)
+	}
+
+	return errors.New("unexpected call to WriteSnapshot")
+}
+
+type mockSnapshotPolicy struct {
+	ShouldSnapshotFn func(typeid.UUID, int64, time.Time) bool
+}
+
+func (m *mockSnapshotPolicy) ShouldSnapshot(aggregateID typeid.UUID, version int64, timestamp time.Time) bool {
+	if m.ShouldSnapshotFn != nil {
+		return m.ShouldSnapshotFn(aggregateID, version, timestamp)
+	}
+
+	return false
+}
+
+func TestNewSnapshottingStore(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name               string
+		haveInner          aggregatestore.Store[*mockEntity]
+		haveSnapshotStore  aggregatestore.SnapshotStore
+		haveSnapshotPolicy aggregatestore.SnapshotPolicy
+		haveOpts           []aggregatestore.SnapshottingStoreOption[*mockEntity]
+		wantErr            error
+	}{
+		{
+			name:               "creates a new snapshotting store with default options",
+			haveInner:          &mockStore2[*mockEntity]{},
+			haveSnapshotStore:  &mockSnapshotStore{},
+			haveSnapshotPolicy: &mockSnapshotPolicy{},
+		},
+		{
+			name:               "creates a new snapshotting store with a custom snapshot marshaler",
+			haveInner:          &mockStore2[*mockEntity]{},
+			haveSnapshotStore:  &mockSnapshotStore{},
+			haveSnapshotPolicy: &mockSnapshotPolicy{},
+			haveOpts: []aggregatestore.SnapshottingStoreOption[*mockEntity]{
+				aggregatestore.WithSnapshotMarshaler(estoria.JSONMarshaler[*mockEntity]{}),
+			},
+		},
+		{
+			name:               "creates a new snapshotting store with a custom snapshot reader",
+			haveInner:          &mockStore2[*mockEntity]{},
+			haveSnapshotStore:  &mockSnapshotStore{},
+			haveSnapshotPolicy: &mockSnapshotPolicy{},
+			haveOpts: []aggregatestore.SnapshottingStoreOption[*mockEntity]{
+				aggregatestore.WithSnapshotReader[*mockEntity](&mockSnapshotStore{}),
+			},
+		},
+		{
+			name:               "creates a new snapshotting store with a custom snapshot writer",
+			haveInner:          &mockStore2[*mockEntity]{},
+			haveSnapshotStore:  &mockSnapshotStore{},
+			haveSnapshotPolicy: &mockSnapshotPolicy{},
+			haveOpts: []aggregatestore.SnapshottingStoreOption[*mockEntity]{
+				aggregatestore.WithSnapshotWriter[*mockEntity](&mockSnapshotStore{}),
+			},
+		},
+		{
+			name:               "returns an error when the inner store is nil",
+			haveInner:          nil,
+			haveSnapshotStore:  &mockSnapshotStore{},
+			haveSnapshotPolicy: &mockSnapshotPolicy{},
+			wantErr:            errors.New("inner store is required"),
+		},
+		{
+			name:               "returns an error when the snapshot store is nil",
+			haveInner:          &mockStore2[*mockEntity]{},
+			haveSnapshotStore:  nil,
+			haveSnapshotPolicy: &mockSnapshotPolicy{},
+			wantErr:            errors.New("snapshot store is required"),
+		},
+		{
+			name:               "returns an error when the snapshot policy is nil",
+			haveInner:          &mockStore2[*mockEntity]{},
+			haveSnapshotStore:  &mockSnapshotStore{},
+			haveSnapshotPolicy: nil,
+			wantErr:            errors.New("snapshot policy is required"),
+		},
+		{
+			name:               "returns an error when applying an option fails",
+			haveInner:          &mockStore2[*mockEntity]{},
+			haveSnapshotStore:  &mockSnapshotStore{},
+			haveSnapshotPolicy: &mockSnapshotPolicy{},
+			haveOpts: []aggregatestore.SnapshottingStoreOption[*mockEntity]{
+				func(*aggregatestore.SnapshottingStore[*mockEntity]) error {
+					return errors.New("mock error")
+				},
+			},
+			wantErr: errors.New("applying option: mock error"),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotStore, gotErr := aggregatestore.NewSnapshottingStore(
+				tt.haveInner,
+				tt.haveSnapshotStore,
+				tt.haveSnapshotPolicy,
+				tt.haveOpts...,
+			)
+			if tt.wantErr != nil {
+				if gotErr == nil || gotErr.Error() != tt.wantErr.Error() {
+					t.Errorf("want error: %v, got: %v", tt.wantErr, gotErr)
+				}
+				return
+			}
+
+			if gotStore == nil {
+				t.Error("unexpected nil store")
+			}
+		})
+	}
+}
+
+func TestSnapshottingStore_New(t *testing.T) {
+	t.Parallel()
+
+	aggregateID := typeid.Must(typeid.NewUUID("mockentity")).(typeid.UUID)
+
+	for _, tt := range []struct {
+		name          string
+		haveInner     aggregatestore.Store[*mockEntity]
+		wantAggregate *aggregatestore.Aggregate[*mockEntity]
+		wantErr       error
+	}{
+		{
+			name: "creates a new aggregate using the inner store",
+			haveInner: &mockStore2[*mockEntity]{
+				NewFn: func(id uuid.UUID) (*aggregatestore.Aggregate[*mockEntity], error) {
+					agg := &aggregatestore.Aggregate[*mockEntity]{}
+					agg.State().SetEntityAtVersion(&mockEntity{ID: typeid.FromUUID("mockentity", id)}, 42)
+					return agg, nil
+				},
+			},
+			wantAggregate: func() *aggregatestore.Aggregate[*mockEntity] {
+				agg := &aggregatestore.Aggregate[*mockEntity]{}
+				agg.State().SetEntityAtVersion(&mockEntity{ID: aggregateID}, 42)
+				return agg
+			}(),
+		},
+		{
+			name: "returns an error when the inner store returns an error",
+			haveInner: &mockStore2[*mockEntity]{
+				NewFn: func(_ uuid.UUID) (*aggregatestore.Aggregate[*mockEntity], error) {
+					return nil, errors.New("mock error")
+				},
+			},
+			wantErr: errors.New("mock error"),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			store, err := aggregatestore.NewSnapshottingStore(
+				tt.haveInner,
+				&mockSnapshotStore{},
+				&mockSnapshotPolicy{},
+			)
+			if err != nil {
+				t.Fatalf("unexpected error creating store: %v", err)
+			} else if store == nil {
+				t.Fatal("unexpected nil store")
+			}
+
+			gotAggregate, gotErr := store.New(aggregateID.UUID())
+
+			if tt.wantErr != nil {
+				if gotErr == nil || gotErr.Error() != tt.wantErr.Error() {
+					t.Errorf("want error: %v, got: %v", tt.wantErr, gotErr)
+				}
+				return
+			}
+
+			if gotErr != nil {
+				t.Errorf("unexpected error: %v", gotErr)
+			} else if gotAggregate == nil {
+				t.Errorf("unexpected nil aggregate")
+			}
+
+			// aggregate has the correct ID
+			if gotAggregate.ID().String() != typeid.FromUUID("mockentity", aggregateID.UUID()).String() {
+				t.Errorf("want aggregate ID %s, got %s", typeid.FromUUID("mockentity", aggregateID.UUID()), gotAggregate.ID())
+			}
+			// aggregate has the correct version
+			if gotAggregate.Version() != tt.wantAggregate.Version() {
+				t.Errorf("want aggregate version %d, got %d", tt.wantAggregate.Version(), gotAggregate.Version())
+			}
+		})
+	}
+}
+
+func TestSnapshottingStore_Load(t *testing.T) {
+	t.Parallel()
+
+	aggregateID := typeid.Must(typeid.NewUUID("mockentity")).(typeid.UUID)
+
+	for _, tt := range []struct {
+		name                      string
+		haveInner                 aggregatestore.Store[*mockEntity]
+		haveSnapshotStore         aggregatestore.SnapshotStore
+		haveSnapshottingStoreOpts []aggregatestore.SnapshottingStoreOption[*mockEntity]
+		haveAggregateID           typeid.UUID
+		haveOpts                  aggregatestore.LoadOptions
+		wantAggregate             *aggregatestore.Aggregate[*mockEntity]
+		wantErr                   error
+	}{
+		{
+			name: "creates a new aggregate and hydrates it using default options",
+			haveInner: &mockStore2[*mockEntity]{
+				NewFn: func(id uuid.UUID) (*aggregatestore.Aggregate[*mockEntity], error) {
+					agg := &aggregatestore.Aggregate[*mockEntity]{}
+					agg.State().SetEntityAtVersion(&mockEntity{ID: typeid.FromUUID("mockentity", id)}, 0)
+					return agg, nil
+				},
+				HydrateFn: func(_ context.Context, _ *aggregatestore.Aggregate[*mockEntity], _ aggregatestore.HydrateOptions) error {
+					return nil
+				},
+			},
+			haveSnapshotStore: &mockSnapshotStore{
+				ReadSnapshotFn: func(_ context.Context, id typeid.UUID, _ snapshotstore.ReadSnapshotOptions) (*snapshotstore.AggregateSnapshot, error) {
+					return &snapshotstore.AggregateSnapshot{
+						AggregateID:      id,
+						AggregateVersion: 12,
+						Data:             []byte(`{"key":"value"}`),
+					}, nil
+				},
+			},
+			haveAggregateID: aggregateID,
+			wantAggregate: func() *aggregatestore.Aggregate[*mockEntity] {
+				agg := &aggregatestore.Aggregate[*mockEntity]{}
+				agg.State().SetEntityAtVersion(&mockEntity{ID: aggregateID}, 12)
+				return agg
+			}(),
+		},
+		{
+			name: "passes the correct ToVersion hydrate option",
+			haveInner: &mockStore2[*mockEntity]{
+				NewFn: func(id uuid.UUID) (*aggregatestore.Aggregate[*mockEntity], error) {
+					agg := &aggregatestore.Aggregate[*mockEntity]{}
+					agg.State().SetEntityAtVersion(&mockEntity{ID: typeid.FromUUID("mockentity", id)}, 0)
+					return agg, nil
+				},
+				HydrateFn: func(_ context.Context, _ *aggregatestore.Aggregate[*mockEntity], opts aggregatestore.HydrateOptions) error {
+					if opts.ToVersion != 42 {
+						return fmt.Errorf("want hydrate opts ToVersion 42, got %d", opts.ToVersion)
+					}
+
+					return nil
+				},
+			},
+			haveSnapshotStore: &mockSnapshotStore{
+				ReadSnapshotFn: func(_ context.Context, id typeid.UUID, _ snapshotstore.ReadSnapshotOptions) (*snapshotstore.AggregateSnapshot, error) {
+					return &snapshotstore.AggregateSnapshot{
+						AggregateID:      id,
+						AggregateVersion: 42,
+						Data:             []byte(`{"key":"value"}`),
+					}, nil
+				},
+			},
+			haveAggregateID: aggregateID,
+			haveOpts: aggregatestore.LoadOptions{
+				ToVersion: 42,
+			},
+			wantAggregate: func() *aggregatestore.Aggregate[*mockEntity] {
+				agg := &aggregatestore.Aggregate[*mockEntity]{}
+				agg.State().SetEntityAtVersion(&mockEntity{ID: aggregateID}, 42)
+				return agg
+			}(),
+		},
+		{
+			name: "falls back to loading using the inner store when creating the aggregate fails",
+			haveInner: &mockStore2[*mockEntity]{
+				NewFn: func(_ uuid.UUID) (*aggregatestore.Aggregate[*mockEntity], error) {
+					return nil, errors.New("mock error")
+				},
+				LoadFn: func(_ context.Context, id typeid.UUID, _ aggregatestore.LoadOptions) (*aggregatestore.Aggregate[*mockEntity], error) {
+					agg := &aggregatestore.Aggregate[*mockEntity]{}
+					agg.State().SetEntityAtVersion(&mockEntity{ID: id}, 42)
+					return agg, nil
+				},
+			},
+			haveSnapshotStore: &mockSnapshotStore{},
+			haveAggregateID:   aggregateID,
+			wantAggregate: func() *aggregatestore.Aggregate[*mockEntity] {
+				agg := &aggregatestore.Aggregate[*mockEntity]{}
+				agg.State().SetEntityAtVersion(&mockEntity{ID: aggregateID}, 42)
+				return agg
+			}(),
+		},
+		{
+			name: "falls back to loading using the inner store when hydrating the aggregate fails",
+			haveInner: &mockStore2[*mockEntity]{
+				NewFn: func(id uuid.UUID) (*aggregatestore.Aggregate[*mockEntity], error) {
+					agg := &aggregatestore.Aggregate[*mockEntity]{}
+					agg.State().SetEntityAtVersion(&mockEntity{ID: typeid.FromUUID("mockentity", id)}, 0)
+					return agg, nil
+				},
+				LoadFn: func(_ context.Context, id typeid.UUID, _ aggregatestore.LoadOptions) (*aggregatestore.Aggregate[*mockEntity], error) {
+					agg := &aggregatestore.Aggregate[*mockEntity]{}
+					agg.State().SetEntityAtVersion(&mockEntity{ID: id}, 42)
+					return agg, nil
+				},
+			},
+			haveSnapshotStore: &mockSnapshotStore{
+				ReadSnapshotFn: func(_ context.Context, _ typeid.UUID, _ snapshotstore.ReadSnapshotOptions) (*snapshotstore.AggregateSnapshot, error) {
+					return nil, errors.New("mock error")
+				},
+			},
+			haveAggregateID: aggregateID,
+			haveOpts: aggregatestore.LoadOptions{
+				ToVersion: 42,
+			},
+			wantAggregate: func() *aggregatestore.Aggregate[*mockEntity] {
+				agg := &aggregatestore.Aggregate[*mockEntity]{}
+				agg.State().SetEntityAtVersion(&mockEntity{ID: aggregateID}, 42)
+				return agg
+			}(),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			store, err := aggregatestore.NewSnapshottingStore(
+				tt.haveInner,
+				tt.haveSnapshotStore,
+				&mockSnapshotPolicy{},
+				tt.haveSnapshottingStoreOpts...,
+			)
+			if err != nil {
+				t.Fatalf("unexpected error creating store: %v", err)
+			} else if store == nil {
+				t.Fatal("unexpected nil store")
+			}
+
+			gotAggregate, gotErr := store.Load(context.Background(), tt.haveAggregateID, tt.haveOpts)
+
+			if tt.wantErr != nil {
+				if gotErr == nil || gotErr.Error() != tt.wantErr.Error() {
+					t.Errorf("want error: %v, got: %v", tt.wantErr, gotErr)
+				}
+				return
+			}
+
+			if gotErr != nil {
+				t.Errorf("unexpected error: %v", gotErr)
+			} else if gotAggregate == nil {
+				t.Errorf("unexpected nil aggregate")
+			}
+
+			// aggregate has the correct ID
+			if gotAggregate.ID().String() != typeid.FromUUID("mockentity", aggregateID.UUID()).String() {
+				t.Errorf("want aggregate ID %s, got %s", typeid.FromUUID("mockentity", aggregateID.UUID()), gotAggregate.ID())
+			}
+			// aggregate has the correct version
+			if gotAggregate.Version() != tt.wantAggregate.Version() {
+				t.Errorf("want aggregate version %d, got %d", tt.wantAggregate.Version(), gotAggregate.Version())
+			}
+		})
+	}
+}
+
+func TestSnapshottingStore_Hydrate(t *testing.T) {
+	t.Parallel()
+
+	aggregateID := typeid.Must(typeid.NewUUID("mockentity")).(typeid.UUID)
+
+	for _, tt := range []struct {
+		name                      string
+		haveInner                 aggregatestore.Store[*mockEntity]
+		haveSnapshotStore         aggregatestore.SnapshotStore
+		haveSnapshottingStoreOpts []aggregatestore.SnapshottingStoreOption[*mockEntity]
+		haveAggregate             *aggregatestore.Aggregate[*mockEntity]
+		haveOpts                  aggregatestore.HydrateOptions
+		wantAggregate             *aggregatestore.Aggregate[*mockEntity]
+		wantErr                   error
+	}{
+		{
+			name: "hydrates an aggregate to a snapshot version",
+			haveInner: &mockStore2[*mockEntity]{
+				NewFn: func(id uuid.UUID) (*aggregatestore.Aggregate[*mockEntity], error) {
+					agg := &aggregatestore.Aggregate[*mockEntity]{}
+					agg.State().SetEntityAtVersion(&mockEntity{ID: typeid.FromUUID("mockentity", id)}, 0)
+					return agg, nil
+				},
+				HydrateFn: func(_ context.Context, _ *aggregatestore.Aggregate[*mockEntity], _ aggregatestore.HydrateOptions) error {
+					return nil
+				},
+			},
+			haveSnapshotStore: &mockSnapshotStore{
+				ReadSnapshotFn: func(_ context.Context, id typeid.UUID, _ snapshotstore.ReadSnapshotOptions) (*snapshotstore.AggregateSnapshot, error) {
+					return &snapshotstore.AggregateSnapshot{
+						AggregateID:      id,
+						AggregateVersion: 42,
+						Data:             []byte(`{"key":"value"}`),
+					}, nil
+				},
+			},
+			haveAggregate: func() *aggregatestore.Aggregate[*mockEntity] {
+				agg := &aggregatestore.Aggregate[*mockEntity]{}
+				agg.State().SetEntityAtVersion(&mockEntity{ID: aggregateID}, 0)
+				return agg
+			}(),
+			haveOpts: aggregatestore.HydrateOptions{
+				ToVersion: 42,
+			},
+			wantAggregate: func() *aggregatestore.Aggregate[*mockEntity] {
+				agg := &aggregatestore.Aggregate[*mockEntity]{}
+				agg.State().SetEntityAtVersion(&mockEntity{ID: aggregateID}, 42)
+				return agg
+			}(),
+		},
+		{
+			name: "hydrates an aggregate to a snapshot version then further hydrates it using the inner store",
+			haveInner: &mockStore2[*mockEntity]{
+				NewFn: func(id uuid.UUID) (*aggregatestore.Aggregate[*mockEntity], error) {
+					agg := &aggregatestore.Aggregate[*mockEntity]{}
+					agg.State().SetEntityAtVersion(&mockEntity{ID: typeid.FromUUID("mockentity", id)}, 0)
+					return agg, nil
+				},
+				HydrateFn: func(_ context.Context, aggregate *aggregatestore.Aggregate[*mockEntity], _ aggregatestore.HydrateOptions) error {
+					aggregate.State().SetEntityAtVersion(aggregate.Entity(), aggregate.Version()+3)
+					return nil
+				},
+			},
+			haveSnapshotStore: &mockSnapshotStore{
+				ReadSnapshotFn: func(_ context.Context, id typeid.UUID, _ snapshotstore.ReadSnapshotOptions) (*snapshotstore.AggregateSnapshot, error) {
+					return &snapshotstore.AggregateSnapshot{
+						AggregateID:      id,
+						AggregateVersion: 42,
+						Data:             []byte(`{"key":"value"}`),
+					}, nil
+				},
+			},
+			haveAggregate: func() *aggregatestore.Aggregate[*mockEntity] {
+				agg := &aggregatestore.Aggregate[*mockEntity]{}
+				agg.State().SetEntityAtVersion(&mockEntity{ID: aggregateID}, 0)
+				return agg
+			}(),
+			wantAggregate: func() *aggregatestore.Aggregate[*mockEntity] {
+				agg := &aggregatestore.Aggregate[*mockEntity]{}
+				agg.State().SetEntityAtVersion(&mockEntity{ID: aggregateID}, 45)
+				return agg
+			}(),
+		},
+		// {
+		// 	name: "passes the correct MaxVersion read snapshot option",
+		// },
+		{
+			name: "falls back to hydrating using the inner store when already at the target version",
+			haveInner: &mockStore2[*mockEntity]{
+				NewFn: func(id uuid.UUID) (*aggregatestore.Aggregate[*mockEntity], error) {
+					agg := &aggregatestore.Aggregate[*mockEntity]{}
+					agg.State().SetEntityAtVersion(&mockEntity{ID: typeid.FromUUID("mockentity", id)}, 0)
+					return agg, nil
+				},
+				HydrateFn: func(_ context.Context, _ *aggregatestore.Aggregate[*mockEntity], _ aggregatestore.HydrateOptions) error {
+					return nil
+				},
+			},
+			haveSnapshotStore: &mockSnapshotStore{},
+			haveAggregate: func() *aggregatestore.Aggregate[*mockEntity] {
+				agg := &aggregatestore.Aggregate[*mockEntity]{}
+				agg.State().SetEntityAtVersion(&mockEntity{ID: aggregateID}, 42)
+				return agg
+			}(),
+			haveOpts: aggregatestore.HydrateOptions{
+				ToVersion: 42,
+			},
+			wantAggregate: func() *aggregatestore.Aggregate[*mockEntity] {
+				agg := &aggregatestore.Aggregate[*mockEntity]{}
+				agg.State().SetEntityAtVersion(&mockEntity{ID: aggregateID}, 42)
+				return agg
+			}(),
+		},
+		{
+			name: "falls back to hydrating using the inner store when target version is less than current version",
+			haveInner: &mockStore2[*mockEntity]{
+				NewFn: func(id uuid.UUID) (*aggregatestore.Aggregate[*mockEntity], error) {
+					agg := &aggregatestore.Aggregate[*mockEntity]{}
+					agg.State().SetEntityAtVersion(&mockEntity{ID: typeid.FromUUID("mockentity", id)}, 0)
+					return agg, nil
+				},
+				HydrateFn: func(_ context.Context, _ *aggregatestore.Aggregate[*mockEntity], _ aggregatestore.HydrateOptions) error {
+					return nil
+				},
+			},
+			haveSnapshotStore: &mockSnapshotStore{},
+			haveAggregate: func() *aggregatestore.Aggregate[*mockEntity] {
+				agg := &aggregatestore.Aggregate[*mockEntity]{}
+				agg.State().SetEntityAtVersion(&mockEntity{ID: aggregateID}, 42)
+				return agg
+			}(),
+			haveOpts: aggregatestore.HydrateOptions{
+				ToVersion: 37,
+			},
+			wantAggregate: func() *aggregatestore.Aggregate[*mockEntity] {
+				agg := &aggregatestore.Aggregate[*mockEntity]{}
+				agg.State().SetEntityAtVersion(&mockEntity{ID: aggregateID}, 42)
+				return agg
+			}(),
+		},
+		{
+			name: "falls back to hydrating using the inner store when reading a snapshot fails",
+			haveInner: &mockStore2[*mockEntity]{
+				NewFn: func(id uuid.UUID) (*aggregatestore.Aggregate[*mockEntity], error) {
+					agg := &aggregatestore.Aggregate[*mockEntity]{}
+					agg.State().SetEntityAtVersion(&mockEntity{ID: typeid.FromUUID("mockentity", id)}, 0)
+					return agg, nil
+				},
+				HydrateFn: func(_ context.Context, aggregate *aggregatestore.Aggregate[*mockEntity], _ aggregatestore.HydrateOptions) error {
+					aggregate.State().SetEntityAtVersion(aggregate.Entity(), aggregate.Version()+3)
+					return nil
+				},
+			},
+			haveSnapshotStore: &mockSnapshotStore{
+				ReadSnapshotFn: func(_ context.Context, _ typeid.UUID, _ snapshotstore.ReadSnapshotOptions) (*snapshotstore.AggregateSnapshot, error) {
+					return nil, errors.New("mock error")
+				},
+			},
+			haveAggregate: func() *aggregatestore.Aggregate[*mockEntity] {
+				agg := &aggregatestore.Aggregate[*mockEntity]{}
+				agg.State().SetEntityAtVersion(&mockEntity{ID: aggregateID}, 42)
+				return agg
+			}(),
+			wantAggregate: func() *aggregatestore.Aggregate[*mockEntity] {
+				agg := &aggregatestore.Aggregate[*mockEntity]{}
+				agg.State().SetEntityAtVersion(&mockEntity{ID: aggregateID}, 45)
+				return agg
+			}(),
+		},
+		{
+			name: "falls back to hydrating using the inner store when no snapshot is available",
+			haveInner: &mockStore2[*mockEntity]{
+				NewFn: func(id uuid.UUID) (*aggregatestore.Aggregate[*mockEntity], error) {
+					agg := &aggregatestore.Aggregate[*mockEntity]{}
+					agg.State().SetEntityAtVersion(&mockEntity{ID: typeid.FromUUID("mockentity", id)}, 0)
+					return agg, nil
+				},
+				HydrateFn: func(_ context.Context, aggregate *aggregatestore.Aggregate[*mockEntity], _ aggregatestore.HydrateOptions) error {
+					aggregate.State().SetEntityAtVersion(aggregate.Entity(), aggregate.Version()+3)
+					return nil
+				},
+			},
+			haveSnapshotStore: &mockSnapshotStore{
+				ReadSnapshotFn: func(_ context.Context, _ typeid.UUID, _ snapshotstore.ReadSnapshotOptions) (*snapshotstore.AggregateSnapshot, error) {
+					return nil, nil
+				},
+			},
+			haveAggregate: func() *aggregatestore.Aggregate[*mockEntity] {
+				agg := &aggregatestore.Aggregate[*mockEntity]{}
+				agg.State().SetEntityAtVersion(&mockEntity{ID: aggregateID}, 42)
+				return agg
+			}(),
+			wantAggregate: func() *aggregatestore.Aggregate[*mockEntity] {
+				agg := &aggregatestore.Aggregate[*mockEntity]{}
+				agg.State().SetEntityAtVersion(&mockEntity{ID: aggregateID}, 45)
+				return agg
+			}(),
+		},
+		{
+			name: "falls back to hydrating using the inner store the snapshot cannot be unmarshaled",
+			haveInner: &mockStore2[*mockEntity]{
+				NewFn: func(id uuid.UUID) (*aggregatestore.Aggregate[*mockEntity], error) {
+					agg := &aggregatestore.Aggregate[*mockEntity]{}
+					agg.State().SetEntityAtVersion(&mockEntity{ID: typeid.FromUUID("mockentity", id)}, 0)
+					return agg, nil
+				},
+				HydrateFn: func(_ context.Context, aggregate *aggregatestore.Aggregate[*mockEntity], _ aggregatestore.HydrateOptions) error {
+					aggregate.State().SetEntityAtVersion(aggregate.Entity(), aggregate.Version()+3)
+					return nil
+				},
+			},
+			haveSnapshotStore: &mockSnapshotStore{
+				ReadSnapshotFn: func(_ context.Context, _ typeid.UUID, _ snapshotstore.ReadSnapshotOptions) (*snapshotstore.AggregateSnapshot, error) {
+					return &snapshotstore.AggregateSnapshot{
+						AggregateID:      aggregateID,
+						AggregateVersion: 42,
+						Data:             []byte(`invalid json`),
+					}, nil
+				},
+			},
+			haveSnapshottingStoreOpts: []aggregatestore.SnapshottingStoreOption[*mockEntity]{
+				aggregatestore.WithSnapshotMarshaler(estoria.JSONMarshaler[*mockEntity]{}),
+			},
+			haveAggregate: func() *aggregatestore.Aggregate[*mockEntity] {
+				agg := &aggregatestore.Aggregate[*mockEntity]{}
+				agg.State().SetEntityAtVersion(&mockEntity{ID: aggregateID}, 42)
+				return agg
+			}(),
+			wantAggregate: func() *aggregatestore.Aggregate[*mockEntity] {
+				agg := &aggregatestore.Aggregate[*mockEntity]{}
+				agg.State().SetEntityAtVersion(&mockEntity{ID: aggregateID}, 45)
+				return agg
+			}(),
+		},
+		{
+			name: "returns an error when the aggregate is nil",
+			haveInner: &mockStore2[*mockEntity]{
+				NewFn: func(id uuid.UUID) (*aggregatestore.Aggregate[*mockEntity], error) {
+					agg := &aggregatestore.Aggregate[*mockEntity]{}
+					agg.State().SetEntityAtVersion(&mockEntity{ID: typeid.FromUUID("mockentity", id)}, 0)
+					return agg, nil
+				},
+			},
+			haveSnapshotStore: &mockSnapshotStore{},
+			haveAggregate:     nil,
+			wantErr:           aggregatestore.HydrateAggregateError{Err: errors.New("aggregate is nil")},
+		},
+		{
+			name: "returns an error when the target version is invalid",
+			haveInner: &mockStore2[*mockEntity]{
+				NewFn: func(id uuid.UUID) (*aggregatestore.Aggregate[*mockEntity], error) {
+					agg := &aggregatestore.Aggregate[*mockEntity]{}
+					agg.State().SetEntityAtVersion(&mockEntity{ID: typeid.FromUUID("mockentity", id)}, 0)
+					return agg, nil
+				},
+			},
+			haveSnapshotStore: &mockSnapshotStore{},
+			haveAggregate: func() *aggregatestore.Aggregate[*mockEntity] {
+				agg := &aggregatestore.Aggregate[*mockEntity]{}
+				agg.State().SetEntityAtVersion(&mockEntity{ID: aggregateID}, 42)
+				return agg
+			}(),
+			haveOpts: aggregatestore.HydrateOptions{
+				ToVersion: -1,
+			},
+			wantErr: aggregatestore.HydrateAggregateError{Err: errors.New("invalid target version")},
+		},
+		{
+			name: "returns an error when the snapshot stoe reader is nil",
+			haveInner: &mockStore2[*mockEntity]{
+				NewFn: func(id uuid.UUID) (*aggregatestore.Aggregate[*mockEntity], error) {
+					agg := &aggregatestore.Aggregate[*mockEntity]{}
+					agg.State().SetEntityAtVersion(&mockEntity{ID: typeid.FromUUID("mockentity", id)}, 0)
+					return agg, nil
+				},
+			},
+			haveSnapshotStore: &mockSnapshotStore{},
+			haveSnapshottingStoreOpts: []aggregatestore.SnapshottingStoreOption[*mockEntity]{
+				aggregatestore.WithSnapshotReader[*mockEntity](nil),
+			},
+			haveAggregate: func() *aggregatestore.Aggregate[*mockEntity] {
+				agg := &aggregatestore.Aggregate[*mockEntity]{}
+				agg.State().SetEntityAtVersion(&mockEntity{ID: aggregateID}, 42)
+				return agg
+			}(),
+			wantErr: aggregatestore.HydrateAggregateError{Err: errors.New("snapshot store has no snapshot reader")},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			store, err := aggregatestore.NewSnapshottingStore(
+				tt.haveInner,
+				tt.haveSnapshotStore,
+				snapshotstore.EventCountSnapshotPolicy{N: 1},
+				tt.haveSnapshottingStoreOpts...,
+			)
+			if err != nil {
+				t.Fatalf("unexpected error creating store: %v", err)
+			} else if store == nil {
+				t.Fatal("unexpected nil store")
+			}
+
+			gotAggregate := tt.haveAggregate
+			gotErr := store.Hydrate(context.Background(), gotAggregate, tt.haveOpts)
+
+			if tt.wantErr != nil {
+				if gotErr == nil || gotErr.Error() != tt.wantErr.Error() {
+					t.Errorf("want error: %v, got: %v", tt.wantErr, gotErr)
+				}
+				return
+			}
+
+			if gotErr != nil {
+				t.Errorf("unexpected error: %v", gotErr)
+			} else if gotAggregate == nil {
+				t.Errorf("unexpected nil aggregate")
+			}
+
+			// aggregate has the correct ID
+			if gotAggregate.ID().String() != typeid.FromUUID("mockentity", aggregateID.UUID()).String() {
+				t.Errorf("want aggregate ID %s, got %s", typeid.FromUUID("mockentity", aggregateID.UUID()), gotAggregate.ID())
+			}
+			// aggregate has the correct version
+			if gotAggregate.Version() != tt.wantAggregate.Version() {
+				t.Errorf("want aggregate version %d, got %d", tt.wantAggregate.Version(), gotAggregate.Version())
+			}
+		})
+	}
+}
+
+// func TestSnapshottingStore_Save(t *testing.T) {
+// 	t.Parallel()
+
+// 	aggregateID := typeid.Must(typeid.NewUUID("mockentity")).(typeid.UUID)
+
+// 	for _, tt := range []struct {
+// 		name                      string
+// 		haveInner                 aggregatestore.Store[*mockEntity]
+// 		haveSnapshotStore         aggregatestore.SnapshotStore
+// 		haveSnapshotPolicy        aggregatestore.SnapshotPolicy
+// 		haveSnapshottingStoreOpts []aggregatestore.SnapshottingStoreOption[*mockEntity]
+// 		haveAggregate             *aggregatestore.Aggregate[*mockEntity]
+// 		haveOpts                  aggregatestore.SaveOptions
+// 		wantAggregate             *aggregatestore.Aggregate[*mockEntity]
+// 		wantErr                   error
+// 	}{
+// 		{
+// 			name: "saves an aggregate using the inner store and adds the aggregate to the cache",
+// 		},
+// 	} {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			t.Parallel()
+
+// 			store, err := aggregatestore.NewSnapshottingStore(tt.haveInner,
+// 				tt.haveSnapshotStore,
+// 				tt.haveSnapshotPolicy,
+// 				tt.haveSnapshottingStoreOpts...,
+// 			)
+// 			if err != nil {
+// 				t.Fatalf("unexpected error creating store: %v", err)
+// 			} else if store == nil {
+// 				t.Fatal("unexpected nil store")
+// 			}
+
+// 			gotAggregate := tt.haveAggregate
+// 			gotErr := store.Save(context.Background(), gotAggregate, tt.haveOpts)
+
+// 			if tt.wantErr != nil {
+// 				if gotErr == nil || gotErr.Error() != tt.wantErr.Error() {
+// 					t.Errorf("want error: %v, got: %v", tt.wantErr, gotErr)
+// 				}
+// 				return
+// 			}
+
+// 			if gotErr != nil {
+// 				t.Errorf("unexpected error: %v", gotErr)
+// 			} else if gotAggregate == nil {
+// 				t.Errorf("unexpected nil aggregate")
+// 			}
+
+// 			// aggregate has the correct ID
+// 			if gotAggregate.ID().String() != typeid.FromUUID("mockentity", aggregateID.UUID()).String() {
+// 				t.Errorf("want aggregate ID %s, got %s", typeid.FromUUID("mockentity", aggregateID.UUID()), gotAggregate.ID())
+// 			}
+// 			// aggregate has the correct version
+// 			if gotAggregate.Version() != tt.wantAggregate.Version() {
+// 				t.Errorf("want aggregate version %d, got %d", tt.wantAggregate.Version(), gotAggregate.Version())
+// 			}
+// 		})
+// 	}
+// }

--- a/eventstore/event_store.go
+++ b/eventstore/event_store.go
@@ -2,7 +2,7 @@ package eventstore
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"time"
 
 	"github.com/go-estoria/estoria/typeid"
@@ -75,9 +75,6 @@ type AppendStreamOptions struct {
 	ExpectVersion int64
 }
 
-// ErrStreamVersionMismatch is returned when the expected stream version does not match the actual stream version.
-var ErrStreamVersionMismatch = errors.New("stream version mismatch")
-
 // An Event is an event that has been read from an event store.
 type Event struct {
 	ID            typeid.UUID
@@ -93,5 +90,63 @@ type WritableEvent struct {
 	Data []byte
 }
 
-// ErrStreamNotFound is returned when a stream is not found.
-var ErrStreamNotFound = errors.New("stream not found")
+type StreamNotFoundError struct {
+	StreamID typeid.UUID
+}
+
+func (e StreamNotFoundError) Error() string {
+	return "stream not found: " + e.StreamID.String()
+}
+
+type EventMarshalingError struct {
+	StreamID typeid.UUID
+	EventID  typeid.UUID
+	Err      error
+}
+
+func (e EventMarshalingError) Error() string {
+	return "marshaling event: " + e.Err.Error()
+}
+
+type EventUnmarshalingError struct {
+	StreamID typeid.UUID
+	EventID  typeid.UUID
+	Err      error
+}
+
+func (e EventUnmarshalingError) Error() string {
+	return "unmarshaling event: " + e.Err.Error()
+}
+
+// StreamVersionMismatchError is returned when the expected stream version does not match the actual stream version.
+type StreamVersionMismatchError struct {
+	StreamID        typeid.UUID
+	EventID         typeid.UUID
+	ExpectedVersion int64
+	ActualVersion   int64
+}
+
+// Error returns the error message.
+func (e StreamVersionMismatchError) Error() string {
+	return fmt.Sprintf("stream version mismatch: expected version %d, got version %d",
+		e.ExpectedVersion,
+		e.ActualVersion)
+}
+
+// InitializationError is returned when an event store fails to initialize.
+type InitializationError struct {
+	Err error
+}
+
+// Error returns the error message.
+func (e InitializationError) Error() string {
+	return "initializing event store: " + e.Err.Error()
+}
+
+type StreamIteratorClosedError struct {
+	StreamID typeid.UUID
+}
+
+func (e StreamIteratorClosedError) Error() string {
+	return "stream is closed: " + e.StreamID.String()
+}

--- a/eventstore/event_store.go
+++ b/eventstore/event_store.go
@@ -63,7 +63,7 @@ const (
 type StreamWriter interface {
 	// AppendStream appends events to an event stream.
 	// The expected version of the stream can be specified in the options.
-	AppendStream(ctx context.Context, streamID typeid.UUID, events []*Event, opts AppendStreamOptions) error
+	AppendStream(ctx context.Context, streamID typeid.UUID, events []*WritableEvent, opts AppendStreamOptions) error
 }
 
 // AppendStreamOptions are options for appending events to a stream.
@@ -78,13 +78,19 @@ type AppendStreamOptions struct {
 // ErrStreamVersionMismatch is returned when the expected stream version does not match the actual stream version.
 var ErrStreamVersionMismatch = errors.New("stream version mismatch")
 
-// An Event can be appended to and loaded from an event store.
+// An Event is an event that has been read from an event store.
 type Event struct {
 	ID            typeid.UUID
 	StreamID      typeid.UUID
 	StreamVersion int64
 	Timestamp     time.Time
 	Data          []byte
+}
+
+// A WritableEvent is an event that can be written to an event store.
+type WritableEvent struct {
+	ID   typeid.UUID
+	Data []byte
 }
 
 // ErrStreamNotFound is returned when a stream is not found.

--- a/eventstore/memory/event_store.go
+++ b/eventstore/memory/event_store.go
@@ -91,6 +91,9 @@ func (s *EventStore) AppendStream(ctx context.Context, streamID typeid.UUID, eve
 
 // ReadStream reads events from a stream.
 func (s *EventStore) ReadStream(ctx context.Context, streamID typeid.UUID, opts eventstore.ReadStreamOptions) (eventstore.StreamIterator, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
 	stream, ok := s.events[streamID.String()]
 	if !ok || len(stream) == 0 {
 		return nil, eventstore.ErrStreamNotFound

--- a/eventstore/memory/event_store.go
+++ b/eventstore/memory/event_store.go
@@ -57,6 +57,7 @@ func (s *EventStore) AppendStream(ctx context.Context, streamID typeid.UUID, eve
 	}
 
 	preparedEvents := []*eventstore.Event{}
+
 	tx := []*eventStoreDocument{}
 	for i, writableEvent := range events {
 		event := &eventstore.Event{
@@ -73,6 +74,7 @@ func (s *EventStore) AppendStream(ctx context.Context, streamID typeid.UUID, eve
 		}
 
 		preparedEvents = append(preparedEvents, event)
+
 		tx = append(tx, &eventStoreDocument{
 			Data: data,
 		})
@@ -101,9 +103,9 @@ func (s *EventStore) ReadStream(ctx context.Context, streamID typeid.UUID, opts 
 
 	if opts.Offset > 0 {
 		if opts.Direction == eventstore.Reverse {
-			cursor -= int64(opts.Offset)
+			cursor -= opts.Offset
 		} else {
-			cursor += int64(opts.Offset)
+			cursor += opts.Offset
 		}
 	}
 

--- a/eventstore/memory/event_store.go
+++ b/eventstore/memory/event_store.go
@@ -109,6 +109,13 @@ func (s *EventStore) ReadStream(ctx context.Context, streamID typeid.UUID, opts 
 // An EventStoreOption configures an EventStore.
 type EventStoreOption func(*EventStore)
 
+// WithEventMarshaler configures the event store to use a custom event marshaler.
+func WithEventMarshaler(marshaler estoria.Marshaler[eventstore.Event, *eventstore.Event]) EventStoreOption {
+	return func(s *EventStore) {
+		s.marshaler = marshaler
+	}
+}
+
 // WithOutbox configures the event store to use an outbox.
 func WithOutbox(outbox *Outbox) EventStoreOption {
 	return func(s *EventStore) {

--- a/eventstore/memory/event_store_test.go
+++ b/eventstore/memory/event_store_test.go
@@ -18,22 +18,22 @@ func TestEventStore_NewEventStore(t *testing.T) {
 		wantErr error
 	}{
 		{
-			name: "with default options, creates a new event store without error",
+			name: "with default options, creates a new event store",
 		},
 		{
-			name: "with a non-nil outbox, creates a new event store without error",
+			name: "with a non-nil outbox, creates a new event store",
 			opts: []memory.EventStoreOption{
 				memory.WithOutbox(memory.NewOutbox()),
 			},
 		},
 		{
-			name: "with a non-nil custom marshaler, creates a new event store without error",
+			name: "with a non-nil custom marshaler, creates a new event store",
 			opts: []memory.EventStoreOption{
 				memory.WithEventMarshaler(failMarshaler{}),
 			},
 		},
 		{
-			name: "with a non-nil outbox and custom marshaler, creates a new event store without error",
+			name: "with a non-nil outbox and custom marshaler, creates a new event store",
 			opts: []memory.EventStoreOption{
 				memory.WithOutbox(memory.NewOutbox()),
 				memory.WithEventMarshaler(failMarshaler{}),
@@ -78,77 +78,47 @@ func TestEventStore_AppendStream(t *testing.T) {
 		haveAppendEvents   []eventSetWithOpts
 	}{
 		{
-			name:         "with default options, appends individual events to a stream without error",
+			name:         "with default options, appends individual events to a stream",
 			haveStreamID: streamID,
 			haveAppendEvents: []eventSetWithOpts{
 				{
 					events: []*eventstore.WritableEvent{
-						{
-							ID:   typeid.Must(typeid.NewUUID("event1")).(typeid.UUID),
-							Data: []byte("event 1 data"),
-						},
+						{ID: typeid.Must(typeid.NewUUID("event1")).(typeid.UUID), Data: []byte("event 1 data")},
 					},
 				},
 				{
 					events: []*eventstore.WritableEvent{
-						{
-							ID:   typeid.Must(typeid.NewUUID("event2")).(typeid.UUID),
-							Data: []byte("event 2 data"),
-						},
+						{ID: typeid.Must(typeid.NewUUID("event2")).(typeid.UUID), Data: []byte("event 2 data")},
 					},
 				},
 				{
 					events: []*eventstore.WritableEvent{
-						{
-							ID:   typeid.Must(typeid.NewUUID("event3")).(typeid.UUID),
-							Data: []byte("event 3 data"),
-						},
+						{ID: typeid.Must(typeid.NewUUID("event3")).(typeid.UUID), Data: []byte("event 3 data")},
 					},
 				},
 			},
 		},
 		{
-			name:         "with default options, appends batches of events to a stream without error",
+			name:         "with default options, appends batches of events to a stream",
 			haveStreamID: streamID,
 			haveAppendEvents: []eventSetWithOpts{
 				{
 					events: []*eventstore.WritableEvent{
-						{
-							ID:   typeid.Must(typeid.NewUUID("event1")).(typeid.UUID),
-							Data: []byte("event 1 data"),
-						},
-						{
-							ID:   typeid.Must(typeid.NewUUID("event2")).(typeid.UUID),
-							Data: []byte("event 2 data"),
-						},
+						{ID: typeid.Must(typeid.NewUUID("event1")).(typeid.UUID), Data: []byte("event 1 data")},
+						{ID: typeid.Must(typeid.NewUUID("event2")).(typeid.UUID), Data: []byte("event 2 data")},
 					},
 				},
 				{
 					events: []*eventstore.WritableEvent{
-						{
-							ID:   typeid.Must(typeid.NewUUID("event1")).(typeid.UUID),
-							Data: []byte("event 3 data"),
-						},
-						{
-							ID:   typeid.Must(typeid.NewUUID("event2")).(typeid.UUID),
-							Data: []byte("event 4 data"),
-						},
-						{
-							ID:   typeid.Must(typeid.NewUUID("event2")).(typeid.UUID),
-							Data: []byte("event 5 data"),
-						},
+						{ID: typeid.Must(typeid.NewUUID("event1")).(typeid.UUID), Data: []byte("event 3 data")},
+						{ID: typeid.Must(typeid.NewUUID("event2")).(typeid.UUID), Data: []byte("event 4 data")},
+						{ID: typeid.Must(typeid.NewUUID("event2")).(typeid.UUID), Data: []byte("event 5 data")},
 					},
 				},
 				{
 					events: []*eventstore.WritableEvent{
-						{
-							ID:   typeid.Must(typeid.NewUUID("event1")).(typeid.UUID),
-							Data: []byte("event 6 data"),
-						},
-						{
-							ID:   typeid.Must(typeid.NewUUID("event2")).(typeid.UUID),
-							Data: []byte("event 7 data"),
-						},
+						{ID: typeid.Must(typeid.NewUUID("event1")).(typeid.UUID), Data: []byte("event 6 data")},
+						{ID: typeid.Must(typeid.NewUUID("event2")).(typeid.UUID), Data: []byte("event 7 data")},
 					},
 				},
 			},
@@ -162,22 +132,13 @@ func TestEventStore_AppendStream(t *testing.T) {
 			haveAppendEvents: []eventSetWithOpts{
 				{
 					events: []*eventstore.WritableEvent{
-						{
-							ID:   typeid.Must(typeid.NewUUID("event1")).(typeid.UUID),
-							Data: []byte("event 1 data"),
-						},
+						{ID: typeid.Must(typeid.NewUUID("event1")).(typeid.UUID), Data: []byte("event 1 data")},
 					},
 				},
 				{
 					events: []*eventstore.WritableEvent{
-						{
-							ID:   typeid.Must(typeid.NewUUID("event2")).(typeid.UUID),
-							Data: []byte("event 2 data"),
-						},
-						{
-							ID:   typeid.Must(typeid.NewUUID("event3")).(typeid.UUID),
-							Data: []byte("event 3 data"),
-						},
+						{ID: typeid.Must(typeid.NewUUID("event2")).(typeid.UUID), Data: []byte("event 2 data")},
+						{ID: typeid.Must(typeid.NewUUID("event3")).(typeid.UUID), Data: []byte("event 3 data")},
 					},
 				},
 			},
@@ -188,22 +149,13 @@ func TestEventStore_AppendStream(t *testing.T) {
 			haveAppendEvents: []eventSetWithOpts{
 				{
 					events: []*eventstore.WritableEvent{
-						{
-							ID:   typeid.Must(typeid.NewUUID("event1")).(typeid.UUID),
-							Data: []byte("event 1 data"),
-						},
-						{
-							ID:   typeid.Must(typeid.NewUUID("event2")).(typeid.UUID),
-							Data: []byte("event 2 data"),
-						},
+						{ID: typeid.Must(typeid.NewUUID("event1")).(typeid.UUID), Data: []byte("event 1 data")},
+						{ID: typeid.Must(typeid.NewUUID("event2")).(typeid.UUID), Data: []byte("event 2 data")},
 					},
 				},
 				{
 					events: []*eventstore.WritableEvent{
-						{
-							ID:   eventID,
-							Data: []byte("event 3 data"),
-						},
+						{ID: eventID, Data: []byte("event 3 data")},
 					},
 					opts: eventstore.AppendStreamOptions{
 						ExpectVersion: 1,
@@ -223,22 +175,13 @@ func TestEventStore_AppendStream(t *testing.T) {
 			haveAppendEvents: []eventSetWithOpts{
 				{
 					events: []*eventstore.WritableEvent{
-						{
-							ID:   typeid.Must(typeid.NewUUID("event1")).(typeid.UUID),
-							Data: []byte("event 1 data"),
-						},
-						{
-							ID:   typeid.Must(typeid.NewUUID("event2")).(typeid.UUID),
-							Data: []byte("event 2 data"),
-						},
+						{ID: typeid.Must(typeid.NewUUID("event1")).(typeid.UUID), Data: []byte("event 1 data")},
+						{ID: typeid.Must(typeid.NewUUID("event2")).(typeid.UUID), Data: []byte("event 2 data")},
 					},
 				},
 				{
 					events: []*eventstore.WritableEvent{
-						{
-							ID:   eventID,
-							Data: []byte("event 3 data"),
-						},
+						{ID: eventID, Data: []byte("event 3 data")},
 					},
 					opts: eventstore.AppendStreamOptions{
 						ExpectVersion: 3,
@@ -257,10 +200,7 @@ func TestEventStore_AppendStream(t *testing.T) {
 			haveAppendEvents: []eventSetWithOpts{
 				{
 					events: []*eventstore.WritableEvent{
-						{
-							ID:   typeid.Must(typeid.NewUUID("event1")).(typeid.UUID),
-							Data: []byte("event 1 data"),
-						},
+						{ID: typeid.Must(typeid.NewUUID("event1")).(typeid.UUID), Data: []byte("event 1 data")},
 					},
 					wantErr: errors.New("marshaling event: fake marshal error"),
 				},
@@ -330,14 +270,220 @@ func TestEventStore_AppendStream(t *testing.T) {
 
 func TestEventStore_ReadStream(t *testing.T) {
 	for _, tt := range []struct {
-		name string
+		name               string
+		haveEvents         []*eventstore.WritableEvent
+		haveStreamID       typeid.UUID
+		haveReadStreamOpts eventstore.ReadStreamOptions
+		wantEvents         []*eventstore.Event
+		wantErr            error
 	}{
 		{
-			name: "",
+			name: "returns a stream iterator for an existing stream",
+			haveEvents: []*eventstore.WritableEvent{
+				{ID: typeid.Must(typeid.NewUUID("event1")).(typeid.UUID), Data: []byte("event 1 data")},
+				{ID: typeid.Must(typeid.NewUUID("event2")).(typeid.UUID), Data: []byte("event 2 data")},
+				{ID: typeid.Must(typeid.NewUUID("event3")).(typeid.UUID), Data: []byte("event 3 data")},
+			},
+			haveStreamID: typeid.Must(typeid.NewUUID("streamtype")).(typeid.UUID),
+			wantEvents: []*eventstore.Event{
+				{StreamVersion: 1, Data: []byte("event 1 data")},
+				{StreamVersion: 2, Data: []byte("event 2 data")},
+				{StreamVersion: 3, Data: []byte("event 3 data")},
+			},
+		},
+		{
+			name: "returns a stream iterator for an existing stream with an initial offset",
+			haveEvents: []*eventstore.WritableEvent{
+				{ID: typeid.Must(typeid.NewUUID("event1")).(typeid.UUID), Data: []byte("event 1 data")},
+				{ID: typeid.Must(typeid.NewUUID("event2")).(typeid.UUID), Data: []byte("event 2 data")},
+				{ID: typeid.Must(typeid.NewUUID("event3")).(typeid.UUID), Data: []byte("event 3 data")},
+			},
+			haveStreamID: typeid.Must(typeid.NewUUID("streamtype")).(typeid.UUID),
+			haveReadStreamOpts: eventstore.ReadStreamOptions{
+				Offset: 1,
+			},
+			wantEvents: []*eventstore.Event{
+				{StreamVersion: 2, Data: []byte("event 2 data")},
+				{StreamVersion: 3, Data: []byte("event 3 data")},
+			},
+		},
+		{
+			name: "returns a stream iterator for an existing stream with a maximum count",
+			haveEvents: []*eventstore.WritableEvent{
+				{ID: typeid.Must(typeid.NewUUID("event1")).(typeid.UUID), Data: []byte("event 1 data")},
+				{ID: typeid.Must(typeid.NewUUID("event2")).(typeid.UUID), Data: []byte("event 2 data")},
+				{ID: typeid.Must(typeid.NewUUID("event3")).(typeid.UUID), Data: []byte("event 3 data")},
+			},
+			haveStreamID: typeid.Must(typeid.NewUUID("streamtype")).(typeid.UUID),
+			haveReadStreamOpts: eventstore.ReadStreamOptions{
+				Count: 2,
+			},
+			wantEvents: []*eventstore.Event{
+				{StreamVersion: 1, Data: []byte("event 1 data")},
+				{StreamVersion: 2, Data: []byte("event 2 data")},
+			},
+		},
+		{
+			name: "returns a stream iterator for an existing stream with an initial offset and maximum count",
+			haveEvents: []*eventstore.WritableEvent{
+				{ID: typeid.Must(typeid.NewUUID("event1")).(typeid.UUID), Data: []byte("event 1 data")},
+				{ID: typeid.Must(typeid.NewUUID("event2")).(typeid.UUID), Data: []byte("event 2 data")},
+				{ID: typeid.Must(typeid.NewUUID("event3")).(typeid.UUID), Data: []byte("event 3 data")},
+				{ID: typeid.Must(typeid.NewUUID("event4")).(typeid.UUID), Data: []byte("event 4 data")},
+				{ID: typeid.Must(typeid.NewUUID("event5")).(typeid.UUID), Data: []byte("event 5 data")},
+			},
+			haveStreamID: typeid.Must(typeid.NewUUID("streamtype")).(typeid.UUID),
+			haveReadStreamOpts: eventstore.ReadStreamOptions{
+				Offset: 2,
+				Count:  2,
+			},
+			wantEvents: []*eventstore.Event{
+				{StreamVersion: 3, Data: []byte("event 3 data")},
+				{StreamVersion: 4, Data: []byte("event 4 data")},
+			},
+		},
+		{
+			name: "returns a stream iterator for an existing stream in reverse order",
+			haveEvents: []*eventstore.WritableEvent{
+				{ID: typeid.Must(typeid.NewUUID("event1")).(typeid.UUID), Data: []byte("event 1 data")},
+				{ID: typeid.Must(typeid.NewUUID("event2")).(typeid.UUID), Data: []byte("event 2 data")},
+				{ID: typeid.Must(typeid.NewUUID("event3")).(typeid.UUID), Data: []byte("event 3 data")},
+			},
+			haveStreamID: typeid.Must(typeid.NewUUID("streamtype")).(typeid.UUID),
+			haveReadStreamOpts: eventstore.ReadStreamOptions{
+				Direction: eventstore.Reverse,
+			},
+			wantEvents: []*eventstore.Event{
+				{StreamVersion: 3, Data: []byte("event 3 data")},
+				{StreamVersion: 2, Data: []byte("event 2 data")},
+				{StreamVersion: 1, Data: []byte("event 1 data")},
+			},
+		},
+		{
+			name: "returns a stream iterator for an existing stream in reverse order with an initial offset",
+			haveEvents: []*eventstore.WritableEvent{
+				{ID: typeid.Must(typeid.NewUUID("event1")).(typeid.UUID), Data: []byte("event 1 data")},
+				{ID: typeid.Must(typeid.NewUUID("event2")).(typeid.UUID), Data: []byte("event 2 data")},
+				{ID: typeid.Must(typeid.NewUUID("event3")).(typeid.UUID), Data: []byte("event 3 data")},
+			},
+			haveStreamID: typeid.Must(typeid.NewUUID("streamtype")).(typeid.UUID),
+			haveReadStreamOpts: eventstore.ReadStreamOptions{
+				Direction: eventstore.Reverse,
+				Offset:    1,
+			},
+			wantEvents: []*eventstore.Event{
+				{StreamVersion: 2, Data: []byte("event 2 data")},
+				{StreamVersion: 1, Data: []byte("event 1 data")},
+			},
+		},
+		{
+			name: "returns a stream iterator for an existing stream in reverse order with a maximum count",
+			haveEvents: []*eventstore.WritableEvent{
+				{ID: typeid.Must(typeid.NewUUID("event1")).(typeid.UUID), Data: []byte("event 1 data")},
+				{ID: typeid.Must(typeid.NewUUID("event2")).(typeid.UUID), Data: []byte("event 2 data")},
+				{ID: typeid.Must(typeid.NewUUID("event3")).(typeid.UUID), Data: []byte("event 3 data")},
+			},
+			haveStreamID: typeid.Must(typeid.NewUUID("streamtype")).(typeid.UUID),
+			haveReadStreamOpts: eventstore.ReadStreamOptions{
+				Direction: eventstore.Reverse,
+				Count:     2,
+			},
+			wantEvents: []*eventstore.Event{
+				{StreamVersion: 3, Data: []byte("event 3 data")},
+				{StreamVersion: 2, Data: []byte("event 2 data")},
+			},
+		},
+		{
+			name: "returns a stream iterator for an existing stream in reverse order with an initial offset and maximum count",
+			haveEvents: []*eventstore.WritableEvent{
+				{ID: typeid.Must(typeid.NewUUID("event1")).(typeid.UUID), Data: []byte("event 1 data")},
+				{ID: typeid.Must(typeid.NewUUID("event2")).(typeid.UUID), Data: []byte("event 2 data")},
+				{ID: typeid.Must(typeid.NewUUID("event3")).(typeid.UUID), Data: []byte("event 3 data")},
+				{ID: typeid.Must(typeid.NewUUID("event4")).(typeid.UUID), Data: []byte("event 4 data")},
+				{ID: typeid.Must(typeid.NewUUID("event5")).(typeid.UUID), Data: []byte("event 5 data")},
+			},
+			haveStreamID: typeid.Must(typeid.NewUUID("streamtype")).(typeid.UUID),
+			haveReadStreamOpts: eventstore.ReadStreamOptions{
+				Direction: eventstore.Reverse,
+				Offset:    2,
+				Count:     2,
+			},
+			wantEvents: []*eventstore.Event{
+				{StreamVersion: 3, Data: []byte("event 3 data")},
+				{StreamVersion: 2, Data: []byte("event 2 data")},
+			},
+		},
+		{
+			name:         "returns ErrStreamNotFound for a non-existent stream",
+			haveStreamID: typeid.Must(typeid.NewUUID("streamtype")).(typeid.UUID),
+			wantEvents: []*eventstore.Event{
+				{StreamVersion: 1, Data: []byte("event 1 data")},
+				{StreamVersion: 2, Data: []byte("event 2 data")},
+				{StreamVersion: 3, Data: []byte("event 3 data")},
+			},
+			wantErr: eventstore.ErrStreamNotFound,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Skip("todo")
+			store, err := memory.NewEventStore()
+			if err != nil {
+				t.Fatalf("NewEventStore() error: %v", err)
+			}
+
+			if err = store.AppendStream(context.Background(), tt.haveStreamID, tt.haveEvents, eventstore.AppendStreamOptions{}); err != nil {
+				t.Fatalf("AppendStream() error: %v", err)
+			}
+
+			iter, err := store.ReadStream(context.Background(), tt.haveStreamID, tt.haveReadStreamOpts)
+			if tt.wantErr != nil {
+				if err == nil || err.Error() != tt.wantErr.Error() {
+					t.Errorf("unexpected ReadStream() error: wanted %v got %v", tt.wantErr, err)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("ReadStream() error: %v", err)
+			}
+
+			var events []*eventstore.Event
+			for {
+				event, err := iter.Next(context.Background())
+				if err == io.EOF {
+					break
+				} else if err != nil {
+					t.Fatalf("Next() error: %v", err)
+				}
+
+				events = append(events, event)
+			}
+
+			if len(events) != len(tt.wantEvents) {
+				t.Fatalf("unexpected number of events: wanted %d got %d", len(tt.wantEvents), len(events))
+			}
+
+			for i, event := range events {
+
+				if len(event.Data) != len(tt.wantEvents[i].Data) {
+					t.Errorf("unexpected event data: wanted %s got %s", tt.wantEvents[i].Data, event.Data)
+				}
+
+				// all events have the correct stream ID
+				if event.StreamID.String() != tt.haveStreamID.String() {
+					t.Errorf("unexpected stream ID: wanted %s got %s", tt.haveStreamID.String(), event.StreamID.String())
+				}
+
+				// all events have the correct stream version
+				if event.StreamVersion != tt.wantEvents[i].StreamVersion {
+					t.Errorf("unexpected event version: wanted %d got %d", tt.wantEvents[i].StreamVersion, event.StreamVersion)
+				}
+
+				// all events have a valid timestamp
+				if event.Timestamp.IsZero() {
+					t.Errorf("unexpected empty event timestamp")
+				}
+			}
 		})
 	}
 }

--- a/eventstore/memory/event_store_test.go
+++ b/eventstore/memory/event_store_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestEventStore_NewEventStore(t *testing.T) {
+	t.Parallel()
 	for _, tt := range []struct {
 		name    string
 		opts    []memory.EventStoreOption
@@ -52,6 +53,7 @@ func TestEventStore_NewEventStore(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			gotStore, gotErr := memory.NewEventStore(tt.opts...)
 			if tt.wantErr != nil {
 				if gotErr == nil || gotErr.Error() != tt.wantErr.Error() {
@@ -264,6 +266,7 @@ func TestEventStore_AppendStream(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			store, err := memory.NewEventStore(tt.haveEventStoreOpts...)
 			if err != nil {
 				t.Fatalf("NewEventStore() error: %v", err)
@@ -538,6 +541,7 @@ func TestEventStore_ReadStream(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			store, err := memory.NewEventStore()
 			if err != nil {
 				t.Fatalf("NewEventStore() error: %v", err)
@@ -631,7 +635,7 @@ type eventsForStream struct {
 
 func randomEvents(count int) []*eventstore.WritableEvent {
 	events := make([]*eventstore.WritableEvent, count)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		events[i] = &eventstore.WritableEvent{
 			ID:   typeid.Must(typeid.NewUUID(fmt.Sprintf("eventtype%d", i))).(typeid.UUID),
 			Data: []byte(fmt.Sprintf("event data %d", i)),

--- a/eventstore/memory/event_store_test.go
+++ b/eventstore/memory/event_store_test.go
@@ -70,6 +70,7 @@ func TestEventStore_NewEventStore(t *testing.T) {
 }
 
 func TestEventStore_AppendStream(t *testing.T) {
+	t.Parallel()
 	streamIDs := []typeid.UUID{
 		typeid.Must(typeid.NewUUID("streamtype1")).(typeid.UUID),
 		typeid.Must(typeid.NewUUID("streamtype2")).(typeid.UUID),
@@ -366,6 +367,8 @@ func TestEventStore_AppendStream(t *testing.T) {
 }
 
 func TestEventStore_ReadStream(t *testing.T) {
+	t.Parallel()
+
 	// predefined stream IDs used for matching in tests
 	streamIDs := []typeid.UUID{
 		typeid.Must(typeid.NewUUID("streamtype1")).(typeid.UUID),

--- a/eventstore/memory/event_store_test.go
+++ b/eventstore/memory/event_store_test.go
@@ -1,0 +1,131 @@
+package memory_test
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/go-estoria/estoria/eventstore"
+	"github.com/go-estoria/estoria/eventstore/memory"
+	"github.com/go-estoria/estoria/typeid"
+)
+
+func TestEventStore_AppendStream(t *testing.T) {
+	streamID := typeid.Must(typeid.NewUUID("streamtype")).(typeid.UUID)
+
+	for _, tt := range []struct {
+		name                 string
+		haveEventStoreOpts   []memory.EventStoreOption
+		haveStreamID         typeid.UUID
+		haveAppendEvents     []*eventstore.Event
+		haveAppendStreamOpts eventstore.AppendStreamOptions
+		wantAppendErr        error
+	}{
+		{
+			name:         "with default options, appends a single event to a new stream without error",
+			haveStreamID: streamID,
+			haveAppendEvents: []*eventstore.Event{
+				{
+					ID:            typeid.Must(typeid.NewUUID("event1")).(typeid.UUID),
+					StreamID:      streamID,
+					StreamVersion: 1,
+					Timestamp:     time.Now(),
+					Data:          []byte("event data"),
+				},
+			},
+		},
+		{
+			name:         "with default options, appends multiple events to a new stream without error",
+			haveStreamID: streamID,
+			haveAppendEvents: []*eventstore.Event{
+				{
+					ID:            typeid.Must(typeid.NewUUID("event1")).(typeid.UUID),
+					StreamID:      streamID,
+					StreamVersion: 1,
+					Timestamp:     time.Now(),
+					Data:          []byte("event data"),
+				},
+				{
+					ID:            typeid.Must(typeid.NewUUID("event2")).(typeid.UUID),
+					StreamID:      streamID,
+					StreamVersion: 2,
+					Timestamp:     time.Now(),
+					Data:          []byte("event data"),
+				},
+				{
+					ID:            typeid.Must(typeid.NewUUID("event3")).(typeid.UUID),
+					StreamID:      streamID,
+					StreamVersion: 3,
+					Timestamp:     time.Now(),
+					Data:          []byte("event data"),
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			store := memory.NewEventStore(tt.haveEventStoreOpts...)
+			gotErr := store.AppendStream(context.Background(), tt.haveStreamID, tt.haveAppendEvents, tt.haveAppendStreamOpts)
+			if tt.wantAppendErr != nil {
+				if gotErr == nil || gotErr.Error() != tt.wantAppendErr.Error() {
+					t.Errorf("unexpected AppendStream() error: wanted %v got %v", tt.wantAppendErr, gotErr)
+				}
+
+				return
+			}
+
+			iter, err := store.ReadStream(context.Background(), tt.haveStreamID, eventstore.ReadStreamOptions{})
+			if err != nil {
+				t.Fatalf("ReadStream() error: %v", err)
+			}
+
+			var events []*eventstore.Event
+			for {
+				event, err := iter.Next(context.Background())
+				if err == io.EOF {
+					break
+				} else if err != nil {
+					t.Fatalf("Next() error: %v", err)
+				}
+
+				events = append(events, event)
+			}
+
+			if len(events) != len(tt.haveAppendEvents) {
+				t.Errorf("unexpected number of events: wanted %d got %d", len(tt.haveAppendEvents), len(events))
+			}
+
+			for i, event := range events {
+				if event.ID.String() != tt.haveAppendEvents[i].ID.String() {
+					t.Errorf("unexpected event ID: wanted %s got %s", tt.haveAppendEvents[i].ID.String(), event.ID.String())
+				}
+				if event.StreamID.String() != tt.haveStreamID.String() {
+					t.Errorf("unexpected stream ID: wanted %s got %s", tt.haveStreamID.String(), event.StreamID.String())
+				}
+				if event.StreamVersion != tt.haveAppendEvents[i].StreamVersion {
+					t.Errorf("unexpected event version: wanted %d got %d", tt.haveAppendEvents[i].StreamVersion, event.StreamVersion)
+				}
+				if !event.Timestamp.Equal(tt.haveAppendEvents[i].Timestamp) {
+					t.Errorf("unexpected event timestamp: wanted %v got %v", tt.haveAppendEvents[i].Timestamp, event.Timestamp)
+				}
+				if len(event.Data) != len(tt.haveAppendEvents[i].Data) {
+					t.Errorf("unexpected event data length: wanted %v got %v", len(tt.haveAppendEvents[i].Data), len(event.Data))
+				}
+			}
+		})
+	}
+}
+
+func TestEventStore_ReadStream(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+	}{
+		{
+			name: "",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Skip("todo")
+		})
+	}
+}

--- a/eventstore/memory/event_store_test.go
+++ b/eventstore/memory/event_store_test.go
@@ -269,6 +269,15 @@ func TestEventStore_AppendStream(t *testing.T) {
 }
 
 func TestEventStore_ReadStream(t *testing.T) {
+	// predefined event IDs used for matching in tests
+	eventIDs := []typeid.UUID{
+		typeid.Must(typeid.NewUUID("eventtype1")).(typeid.UUID),
+		typeid.Must(typeid.NewUUID("eventtype2")).(typeid.UUID),
+		typeid.Must(typeid.NewUUID("eventtype3")).(typeid.UUID),
+		typeid.Must(typeid.NewUUID("eventtype4")).(typeid.UUID),
+		typeid.Must(typeid.NewUUID("eventtype5")).(typeid.UUID),
+	}
+
 	for _, tt := range []struct {
 		name               string
 		haveEvents         []*eventstore.WritableEvent
@@ -280,57 +289,57 @@ func TestEventStore_ReadStream(t *testing.T) {
 		{
 			name: "returns a stream iterator for an existing stream",
 			haveEvents: []*eventstore.WritableEvent{
-				{ID: typeid.Must(typeid.NewUUID("event1")).(typeid.UUID), Data: []byte("event 1 data")},
-				{ID: typeid.Must(typeid.NewUUID("event2")).(typeid.UUID), Data: []byte("event 2 data")},
-				{ID: typeid.Must(typeid.NewUUID("event3")).(typeid.UUID), Data: []byte("event 3 data")},
+				{ID: eventIDs[0], Data: []byte("event 1 data")},
+				{ID: eventIDs[1], Data: []byte("event 2 data")},
+				{ID: eventIDs[2], Data: []byte("event 3 data")},
 			},
 			haveStreamID: typeid.Must(typeid.NewUUID("streamtype")).(typeid.UUID),
 			wantEvents: []*eventstore.Event{
-				{StreamVersion: 1, Data: []byte("event 1 data")},
-				{StreamVersion: 2, Data: []byte("event 2 data")},
-				{StreamVersion: 3, Data: []byte("event 3 data")},
+				{ID: eventIDs[0], StreamVersion: 1, Data: []byte("event 1 data")},
+				{ID: eventIDs[1], StreamVersion: 2, Data: []byte("event 2 data")},
+				{ID: eventIDs[2], StreamVersion: 3, Data: []byte("event 3 data")},
 			},
 		},
 		{
 			name: "returns a stream iterator for an existing stream with an initial offset",
 			haveEvents: []*eventstore.WritableEvent{
-				{ID: typeid.Must(typeid.NewUUID("event1")).(typeid.UUID), Data: []byte("event 1 data")},
-				{ID: typeid.Must(typeid.NewUUID("event2")).(typeid.UUID), Data: []byte("event 2 data")},
-				{ID: typeid.Must(typeid.NewUUID("event3")).(typeid.UUID), Data: []byte("event 3 data")},
+				{ID: eventIDs[0], Data: []byte("event 1 data")},
+				{ID: eventIDs[1], Data: []byte("event 2 data")},
+				{ID: eventIDs[2], Data: []byte("event 3 data")},
 			},
 			haveStreamID: typeid.Must(typeid.NewUUID("streamtype")).(typeid.UUID),
 			haveReadStreamOpts: eventstore.ReadStreamOptions{
 				Offset: 1,
 			},
 			wantEvents: []*eventstore.Event{
-				{StreamVersion: 2, Data: []byte("event 2 data")},
-				{StreamVersion: 3, Data: []byte("event 3 data")},
+				{ID: eventIDs[1], StreamVersion: 2, Data: []byte("event 2 data")},
+				{ID: eventIDs[2], StreamVersion: 3, Data: []byte("event 3 data")},
 			},
 		},
 		{
 			name: "returns a stream iterator for an existing stream with a maximum count",
 			haveEvents: []*eventstore.WritableEvent{
-				{ID: typeid.Must(typeid.NewUUID("event1")).(typeid.UUID), Data: []byte("event 1 data")},
-				{ID: typeid.Must(typeid.NewUUID("event2")).(typeid.UUID), Data: []byte("event 2 data")},
-				{ID: typeid.Must(typeid.NewUUID("event3")).(typeid.UUID), Data: []byte("event 3 data")},
+				{ID: eventIDs[0], Data: []byte("event 1 data")},
+				{ID: eventIDs[1], Data: []byte("event 2 data")},
+				{ID: eventIDs[2], Data: []byte("event 3 data")},
 			},
 			haveStreamID: typeid.Must(typeid.NewUUID("streamtype")).(typeid.UUID),
 			haveReadStreamOpts: eventstore.ReadStreamOptions{
 				Count: 2,
 			},
 			wantEvents: []*eventstore.Event{
-				{StreamVersion: 1, Data: []byte("event 1 data")},
-				{StreamVersion: 2, Data: []byte("event 2 data")},
+				{ID: eventIDs[0], StreamVersion: 1, Data: []byte("event 1 data")},
+				{ID: eventIDs[1], StreamVersion: 2, Data: []byte("event 2 data")},
 			},
 		},
 		{
 			name: "returns a stream iterator for an existing stream with an initial offset and maximum count",
 			haveEvents: []*eventstore.WritableEvent{
-				{ID: typeid.Must(typeid.NewUUID("event1")).(typeid.UUID), Data: []byte("event 1 data")},
-				{ID: typeid.Must(typeid.NewUUID("event2")).(typeid.UUID), Data: []byte("event 2 data")},
-				{ID: typeid.Must(typeid.NewUUID("event3")).(typeid.UUID), Data: []byte("event 3 data")},
-				{ID: typeid.Must(typeid.NewUUID("event4")).(typeid.UUID), Data: []byte("event 4 data")},
-				{ID: typeid.Must(typeid.NewUUID("event5")).(typeid.UUID), Data: []byte("event 5 data")},
+				{ID: eventIDs[0], Data: []byte("event 1 data")},
+				{ID: eventIDs[1], Data: []byte("event 2 data")},
+				{ID: eventIDs[2], Data: []byte("event 3 data")},
+				{ID: eventIDs[3], Data: []byte("event 4 data")},
+				{ID: eventIDs[4], Data: []byte("event 5 data")},
 			},
 			haveStreamID: typeid.Must(typeid.NewUUID("streamtype")).(typeid.UUID),
 			haveReadStreamOpts: eventstore.ReadStreamOptions{
@@ -338,33 +347,33 @@ func TestEventStore_ReadStream(t *testing.T) {
 				Count:  2,
 			},
 			wantEvents: []*eventstore.Event{
-				{StreamVersion: 3, Data: []byte("event 3 data")},
-				{StreamVersion: 4, Data: []byte("event 4 data")},
+				{ID: eventIDs[2], StreamVersion: 3, Data: []byte("event 3 data")},
+				{ID: eventIDs[3], StreamVersion: 4, Data: []byte("event 4 data")},
 			},
 		},
 		{
 			name: "returns a stream iterator for an existing stream in reverse order",
 			haveEvents: []*eventstore.WritableEvent{
-				{ID: typeid.Must(typeid.NewUUID("event1")).(typeid.UUID), Data: []byte("event 1 data")},
-				{ID: typeid.Must(typeid.NewUUID("event2")).(typeid.UUID), Data: []byte("event 2 data")},
-				{ID: typeid.Must(typeid.NewUUID("event3")).(typeid.UUID), Data: []byte("event 3 data")},
+				{ID: eventIDs[0], Data: []byte("event 1 data")},
+				{ID: eventIDs[1], Data: []byte("event 2 data")},
+				{ID: eventIDs[2], Data: []byte("event 3 data")},
 			},
 			haveStreamID: typeid.Must(typeid.NewUUID("streamtype")).(typeid.UUID),
 			haveReadStreamOpts: eventstore.ReadStreamOptions{
 				Direction: eventstore.Reverse,
 			},
 			wantEvents: []*eventstore.Event{
-				{StreamVersion: 3, Data: []byte("event 3 data")},
-				{StreamVersion: 2, Data: []byte("event 2 data")},
-				{StreamVersion: 1, Data: []byte("event 1 data")},
+				{ID: eventIDs[2], StreamVersion: 3, Data: []byte("event 3 data")},
+				{ID: eventIDs[1], StreamVersion: 2, Data: []byte("event 2 data")},
+				{ID: eventIDs[0], StreamVersion: 1, Data: []byte("event 1 data")},
 			},
 		},
 		{
 			name: "returns a stream iterator for an existing stream in reverse order with an initial offset",
 			haveEvents: []*eventstore.WritableEvent{
-				{ID: typeid.Must(typeid.NewUUID("event1")).(typeid.UUID), Data: []byte("event 1 data")},
-				{ID: typeid.Must(typeid.NewUUID("event2")).(typeid.UUID), Data: []byte("event 2 data")},
-				{ID: typeid.Must(typeid.NewUUID("event3")).(typeid.UUID), Data: []byte("event 3 data")},
+				{ID: eventIDs[0], Data: []byte("event 1 data")},
+				{ID: eventIDs[1], Data: []byte("event 2 data")},
+				{ID: eventIDs[2], Data: []byte("event 3 data")},
 			},
 			haveStreamID: typeid.Must(typeid.NewUUID("streamtype")).(typeid.UUID),
 			haveReadStreamOpts: eventstore.ReadStreamOptions{
@@ -372,16 +381,16 @@ func TestEventStore_ReadStream(t *testing.T) {
 				Offset:    1,
 			},
 			wantEvents: []*eventstore.Event{
-				{StreamVersion: 2, Data: []byte("event 2 data")},
-				{StreamVersion: 1, Data: []byte("event 1 data")},
+				{ID: eventIDs[1], StreamVersion: 2, Data: []byte("event 2 data")},
+				{ID: eventIDs[0], StreamVersion: 1, Data: []byte("event 1 data")},
 			},
 		},
 		{
 			name: "returns a stream iterator for an existing stream in reverse order with a maximum count",
 			haveEvents: []*eventstore.WritableEvent{
-				{ID: typeid.Must(typeid.NewUUID("event1")).(typeid.UUID), Data: []byte("event 1 data")},
-				{ID: typeid.Must(typeid.NewUUID("event2")).(typeid.UUID), Data: []byte("event 2 data")},
-				{ID: typeid.Must(typeid.NewUUID("event3")).(typeid.UUID), Data: []byte("event 3 data")},
+				{ID: eventIDs[0], Data: []byte("event 1 data")},
+				{ID: eventIDs[1], Data: []byte("event 2 data")},
+				{ID: eventIDs[2], Data: []byte("event 3 data")},
 			},
 			haveStreamID: typeid.Must(typeid.NewUUID("streamtype")).(typeid.UUID),
 			haveReadStreamOpts: eventstore.ReadStreamOptions{
@@ -389,18 +398,18 @@ func TestEventStore_ReadStream(t *testing.T) {
 				Count:     2,
 			},
 			wantEvents: []*eventstore.Event{
-				{StreamVersion: 3, Data: []byte("event 3 data")},
-				{StreamVersion: 2, Data: []byte("event 2 data")},
+				{ID: eventIDs[2], StreamVersion: 3, Data: []byte("event 3 data")},
+				{ID: eventIDs[1], StreamVersion: 2, Data: []byte("event 2 data")},
 			},
 		},
 		{
 			name: "returns a stream iterator for an existing stream in reverse order with an initial offset and maximum count",
 			haveEvents: []*eventstore.WritableEvent{
-				{ID: typeid.Must(typeid.NewUUID("event1")).(typeid.UUID), Data: []byte("event 1 data")},
-				{ID: typeid.Must(typeid.NewUUID("event2")).(typeid.UUID), Data: []byte("event 2 data")},
-				{ID: typeid.Must(typeid.NewUUID("event3")).(typeid.UUID), Data: []byte("event 3 data")},
-				{ID: typeid.Must(typeid.NewUUID("event4")).(typeid.UUID), Data: []byte("event 4 data")},
-				{ID: typeid.Must(typeid.NewUUID("event5")).(typeid.UUID), Data: []byte("event 5 data")},
+				{ID: eventIDs[0], Data: []byte("event 1 data")},
+				{ID: eventIDs[1], Data: []byte("event 2 data")},
+				{ID: eventIDs[2], Data: []byte("event 3 data")},
+				{ID: eventIDs[3], Data: []byte("event 4 data")},
+				{ID: eventIDs[4], Data: []byte("event 5 data")},
 			},
 			haveStreamID: typeid.Must(typeid.NewUUID("streamtype")).(typeid.UUID),
 			haveReadStreamOpts: eventstore.ReadStreamOptions{
@@ -409,17 +418,17 @@ func TestEventStore_ReadStream(t *testing.T) {
 				Count:     2,
 			},
 			wantEvents: []*eventstore.Event{
-				{StreamVersion: 3, Data: []byte("event 3 data")},
-				{StreamVersion: 2, Data: []byte("event 2 data")},
+				{ID: eventIDs[2], StreamVersion: 3, Data: []byte("event 3 data")},
+				{ID: eventIDs[1], StreamVersion: 2, Data: []byte("event 2 data")},
 			},
 		},
 		{
 			name:         "returns ErrStreamNotFound for a non-existent stream",
 			haveStreamID: typeid.Must(typeid.NewUUID("streamtype")).(typeid.UUID),
 			wantEvents: []*eventstore.Event{
-				{StreamVersion: 1, Data: []byte("event 1 data")},
-				{StreamVersion: 2, Data: []byte("event 2 data")},
-				{StreamVersion: 3, Data: []byte("event 3 data")},
+				{ID: eventIDs[0], StreamVersion: 1, Data: []byte("event 1 data")},
+				{ID: eventIDs[1], StreamVersion: 2, Data: []byte("event 2 data")},
+				{ID: eventIDs[2], StreamVersion: 3, Data: []byte("event 3 data")},
 			},
 			wantErr: eventstore.ErrStreamNotFound,
 		},
@@ -447,47 +456,61 @@ func TestEventStore_ReadStream(t *testing.T) {
 				t.Fatalf("ReadStream() error: %v", err)
 			}
 
-			var events []*eventstore.Event
+			var gotEvents []*eventstore.Event
 			for {
-				event, err := iter.Next(context.Background())
+				gotEvent, err := iter.Next(context.Background())
 				if err == io.EOF {
 					break
 				} else if err != nil {
 					t.Fatalf("Next() error: %v", err)
 				}
 
-				events = append(events, event)
+				gotEvents = append(gotEvents, gotEvent)
 			}
 
-			if len(events) != len(tt.wantEvents) {
-				t.Fatalf("unexpected number of events: wanted %d got %d", len(tt.wantEvents), len(events))
+			// expected number of events
+			if len(gotEvents) != len(tt.wantEvents) {
+				t.Fatalf("unexpected number of events: wanted %d got %d", len(tt.wantEvents), len(gotEvents))
 			}
 
-			for i, event := range events {
-
-				if len(event.Data) != len(tt.wantEvents[i].Data) {
-					t.Errorf("unexpected event data: wanted %s got %s", tt.wantEvents[i].Data, event.Data)
+			for i, gotEvent := range gotEvents {
+				// all events have the correct ID
+				if gotEvent.ID.String() != tt.wantEvents[i].ID.String() {
+					t.Errorf("unexpected event ID: wanted %s got %s", tt.wantEvents[i].ID.String(), gotEvent.ID.String())
 				}
 
 				// all events have the correct stream ID
-				if event.StreamID.String() != tt.haveStreamID.String() {
-					t.Errorf("unexpected stream ID: wanted %s got %s", tt.haveStreamID.String(), event.StreamID.String())
+				if gotEvent.StreamID.String() != tt.haveStreamID.String() {
+					t.Errorf("unexpected stream ID: wanted %s got %s", tt.haveStreamID.String(), gotEvent.StreamID.String())
 				}
 
 				// all events have the correct stream version
-				if event.StreamVersion != tt.wantEvents[i].StreamVersion {
-					t.Errorf("unexpected event version: wanted %d got %d", tt.wantEvents[i].StreamVersion, event.StreamVersion)
+				if gotEvent.StreamVersion != tt.wantEvents[i].StreamVersion {
+					t.Errorf("unexpected event version: wanted %d got %d", tt.wantEvents[i].StreamVersion, gotEvent.StreamVersion)
 				}
 
 				// all events have a valid timestamp
-				if event.Timestamp.IsZero() {
+				if gotEvent.Timestamp.IsZero() {
 					t.Errorf("unexpected empty event timestamp")
+				}
+
+				// all events have the correct data length
+				if len(gotEvent.Data) != len(tt.wantEvents[i].Data) {
+					t.Errorf("unexpected event data: wanted %s got %s", tt.wantEvents[i].Data, gotEvent.Data)
+				}
+
+				// all events have the correct data
+				if string(gotEvent.Data) != string(tt.wantEvents[i].Data) {
+					t.Errorf("unexpected event data: wanted %s got %s", tt.wantEvents[i].Data, gotEvent.Data)
 				}
 			}
 		})
 	}
 }
 
+// For AppendStream tests. Allows a test case to specify
+// sets of events to append to a stream, with each set
+// optionally specifying append options and an expected error.
 type eventSetWithOpts struct {
 	events  []*eventstore.WritableEvent
 	opts    eventstore.AppendStreamOptions

--- a/eventstore/memory/outbox.go
+++ b/eventstore/memory/outbox.go
@@ -3,6 +3,7 @@ package memory
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"strings"
 	"sync"
@@ -42,7 +43,7 @@ func (o *Outbox) RegisterHandlers(eventType estoria.EntityEvent, handlers ...out
 }
 
 // HandleEvents adds an outbox item for each event.
-func (o *Outbox) HandleEvents(ctx context.Context, events []*eventstore.Event) error {
+func (o *Outbox) HandleEvents(ctx context.Context, events []*eventstore.Event) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 	slog.Debug("inserting events into outbox", "tx", "inherited", "events", len(events))
@@ -63,8 +64,6 @@ func (o *Outbox) HandleEvents(ctx context.Context, events []*eventstore.Event) e
 
 		o.items = append(o.items, item)
 	}
-
-	return nil
 }
 
 // MarkHandled updates the handler result for the outbox item.
@@ -115,7 +114,7 @@ func (i *OutboxIterator) Next(ctx context.Context) (outbox.OutboxItem, error) {
 	}
 
 	if i.cursor >= len(i.outbox.items) {
-		return nil, nil
+		return nil, io.EOF
 	}
 
 	item := i.outbox.items[i.cursor]

--- a/eventstore/memory/outbox.go
+++ b/eventstore/memory/outbox.go
@@ -43,7 +43,7 @@ func (o *Outbox) RegisterHandlers(eventType estoria.EntityEvent, handlers ...out
 }
 
 // HandleEvents adds an outbox item for each event.
-func (o *Outbox) HandleEvents(ctx context.Context, events []*eventstore.Event) {
+func (o *Outbox) HandleEvents(_ context.Context, events []*eventstore.Event) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 	slog.Debug("inserting events into outbox", "tx", "inherited", "events", len(events))

--- a/eventstore/memory/outbox.go
+++ b/eventstore/memory/outbox.go
@@ -67,7 +67,7 @@ func (o *Outbox) HandleEvents(_ context.Context, events []*eventstore.Event) {
 }
 
 // MarkHandled updates the handler result for the outbox item.
-func (o *Outbox) MarkHandled(ctx context.Context, itemID uuid.UUID, result outbox.HandlerResult) error {
+func (o *Outbox) MarkHandled(_ context.Context, itemID uuid.UUID, result outbox.HandlerResult) error {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 
@@ -104,7 +104,7 @@ type OutboxIterator struct {
 }
 
 // Next returns the next outbox entry.
-func (i *OutboxIterator) Next(ctx context.Context) (outbox.OutboxItem, error) {
+func (i *OutboxIterator) Next(_ context.Context) (outbox.OutboxItem, error) {
 	i.outbox.mu.Lock()
 	defer i.outbox.mu.Unlock()
 
@@ -129,7 +129,6 @@ type outboxItem struct {
 	eventID   typeid.UUID
 	eventData []byte
 	handlers  outbox.HandlerResultMap
-	mu        sync.RWMutex
 }
 
 func (e *outboxItem) ID() uuid.UUID {

--- a/eventstore/memory/stream_iterator.go
+++ b/eventstore/memory/stream_iterator.go
@@ -20,7 +20,7 @@ type streamIterator struct {
 	marshaler estoria.Marshaler[eventstore.Event, *eventstore.Event]
 }
 
-func (i *streamIterator) Next(ctx context.Context) (*eventstore.Event, error) {
+func (i *streamIterator) Next(_ context.Context) (*eventstore.Event, error) {
 	if i.events == nil {
 		return nil, fmt.Errorf("stream %s has been closed", i.streamID)
 	} else if i.direction == eventstore.Forward && i.cursor >= int64(len(i.events)) {
@@ -32,6 +32,7 @@ func (i *streamIterator) Next(ctx context.Context) (*eventstore.Event, error) {
 	}
 
 	doc := i.events[i.cursor]
+
 	if i.direction == eventstore.Reverse {
 		i.cursor--
 	} else {

--- a/eventstore/memory/stream_iterator.go
+++ b/eventstore/memory/stream_iterator.go
@@ -10,7 +10,7 @@ import (
 	"github.com/go-estoria/estoria/typeid"
 )
 
-type StreamIterator struct {
+type streamIterator struct {
 	streamID  typeid.UUID
 	events    []*eventStoreDocument
 	cursor    int64
@@ -20,7 +20,7 @@ type StreamIterator struct {
 	marshaler estoria.Marshaler[eventstore.Event, *eventstore.Event]
 }
 
-func (i *StreamIterator) Next(ctx context.Context) (*eventstore.Event, error) {
+func (i *streamIterator) Next(ctx context.Context) (*eventstore.Event, error) {
 	if i.events == nil {
 		return nil, fmt.Errorf("stream %s has been closed", i.streamID)
 	} else if i.direction == eventstore.Forward && i.cursor >= int64(len(i.events)) {
@@ -48,7 +48,7 @@ func (i *StreamIterator) Next(ctx context.Context) (*eventstore.Event, error) {
 	return event, nil
 }
 
-func (i *StreamIterator) Close(ctx context.Context) error {
+func (i *streamIterator) Close(ctx context.Context) error {
 	i.events = nil
 	return nil
 }

--- a/outbox/outbox_processor.go
+++ b/outbox/outbox_processor.go
@@ -118,10 +118,12 @@ func (p *Processor) Handle(ctx context.Context, entry OutboxItem) error {
 
 		if err := handler.Handle(ctx, entry); err != nil {
 			slog.Error("handling outbox item", "handler", handler.Name(), "error", err)
-			p.outbox.MarkHandled(ctx, entry.ID(), HandlerResult{
+			if mhErr := p.outbox.MarkHandled(ctx, entry.ID(), HandlerResult{
 				HandlerName: handler.Name(),
 				Error:       err,
-			})
+			}); mhErr != nil {
+				slog.Error("marking outbox item as handled", "error", mhErr)
+			}
 		} else {
 			p.outbox.MarkHandled(ctx, entry.ID(), HandlerResult{
 				HandlerName: handler.Name(),

--- a/snapshotstore/event_stream_store.go
+++ b/snapshotstore/event_stream_store.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"time"
 
 	"github.com/go-estoria/estoria"
 	"github.com/go-estoria/estoria/eventstore"
@@ -84,12 +83,10 @@ func (s *EventStreamStore) WriteSnapshot(ctx context.Context, snap *AggregateSna
 		return fmt.Errorf("marshaling snapshot data for stream event: %w", err)
 	}
 
-	if err := s.eventWriter.AppendStream(ctx, snapshotStreamID, []*eventstore.Event{
+	if err := s.eventWriter.AppendStream(ctx, snapshotStreamID, []*eventstore.WritableEvent{
 		{
-			ID:        eventID,
-			StreamID:  snapshotStreamID,
-			Timestamp: time.Now(),
-			Data:      eventData,
+			ID:   eventID,
+			Data: eventData,
 		},
 	}, eventstore.AppendStreamOptions{}); err != nil {
 		return fmt.Errorf("appending snapshot stream: %w", err)


### PR DESCRIPTION
- Adds initial round of unit tests for `aggregatestore` and `eventstore/memory`
- Adds initial `golangci-lint` configuration