### PR TITLE
Fix aggregate becoming unloadable when a snapshot lands on the stream tip

### DIFF
--- a/aggregatestore/event_sourced_store.go
+++ b/aggregatestore/event_sourced_store.go
@@ -130,6 +130,25 @@ func (s *EventSourcedStore[E]) Hydrate(ctx context.Context, aggregate *Aggregate
 
 	iter, err := s.eventReader.ReadStream(ctx, aggregate.ID(), readOpts)
 	if errors.Is(err, eventstore.ErrStreamNotFound) {
+		// A read filtered by AfterVersion is not a reliable signal of whether the aggregate
+		// exists: it asks only for events newer than a version the aggregate has already
+		// reached. Existence is decided by the aggregate's own state — one that already
+		// carries state (from a snapshot, or an earlier partial hydrate) exists, so an empty
+		// read past its version means there is nothing newer to apply, not that it is gone.
+		// Only an unfiltered read can report absence, which is why an aggregate at version 0
+		// still maps to ErrAggregateNotFound.
+		//
+		// This deliberately gives up one distinction. A store that follows the convention in
+		// StreamReader.ReadStream returns an empty iterator for an empty filtered read, so
+		// its ErrStreamNotFound here would mean the stream was genuinely deleted; that case
+		// now hydrates to the stale snapshot rather than reporting not-found.
+		if readOpts.AfterVersion > 0 {
+			s.log.Debug("no events found after aggregate version, nothing to hydrate",
+				"aggregate_id", aggregate.ID(),
+				"version", aggregate.Version())
+			return nil
+		}
+
 		return HydrateError{AggregateID: aggregate.ID(), Err: ErrAggregateNotFound}
 	} else if err != nil {
 		return HydrateError{AggregateID: aggregate.ID(), Operation: "reading event stream", Err: err}

--- a/aggregatestore/event_sourced_store_test.go
+++ b/aggregatestore/event_sourced_store_test.go
@@ -1136,6 +1136,49 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 			wantErr: errors.New("aggregate not found"),
 		},
 		{
+			// An aggregate that already has state exists, so a store reporting an empty
+			// filtered read as a missing stream means "nothing newer", not "not found".
+			name: "hydrates nothing when the event stream is not found for an aggregate that already has state",
+			haveEventStore: func() eventstore.Store {
+				store, _ := memory.NewEventStore()
+				return store
+			},
+			haveStoreOpts: []aggregatestore.EventSourcedStoreOption[mockEntity]{
+				aggregatestore.WithEventStreamReader[mockEntity](mockStreamReader{
+					readStreamErr: eventstore.ErrStreamNotFound,
+				}),
+			},
+			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
+				return aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 10)
+			},
+			wantVersion: 10,
+			wantEntity: mockEntity{
+				ID: aggregateID,
+			},
+		},
+		{
+			// Consistent with a store that returns an empty iterator instead: the target
+			// version is simply not reached, which is not an error.
+			name: "hydrates nothing when the event stream is not found for an aggregate that already has state and a target version is set",
+			haveEventStore: func() eventstore.Store {
+				store, _ := memory.NewEventStore()
+				return store
+			},
+			haveStoreOpts: []aggregatestore.EventSourcedStoreOption[mockEntity]{
+				aggregatestore.WithEventStreamReader[mockEntity](mockStreamReader{
+					readStreamErr: eventstore.ErrStreamNotFound,
+				}),
+			},
+			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
+				return aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 10)
+			},
+			haveHydrateOpts: &aggregatestore.HydrateOptions{ToVersion: 15},
+			wantVersion:     10,
+			wantEntity: mockEntity{
+				ID: aggregateID,
+			},
+		},
+		{
 			name: "returns an error when unable to obtain an event stream iterator",
 			haveEventStore: func() eventstore.Store {
 				events := []*eventstore.WritableEvent{}
@@ -1310,8 +1353,8 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 				return
 			}
 
-			if err != nil {
-				t.Errorf("unexpected error: %v", err)
+			if gotErr != nil {
+				t.Fatalf("unexpected error: %v", gotErr)
 			}
 
 			// aggregate has the correct ID
@@ -1638,8 +1681,8 @@ func TestEventSourcedStore_SaveAggregate(t *testing.T) {
 				return
 			}
 
-			if err != nil {
-				t.Errorf("unexpected error: %v", err)
+			if gotErr != nil {
+				t.Fatalf("unexpected error: %v", gotErr)
 			}
 
 			// aggregate has the correct ID

--- a/aggregatestore/snapshotting_store_test.go
+++ b/aggregatestore/snapshotting_store_test.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/go-estoria/estoria"
 	"github.com/go-estoria/estoria/aggregatestore"
+	"github.com/go-estoria/estoria/eventstore"
+	"github.com/go-estoria/estoria/eventstore/memory"
 	"github.com/go-estoria/estoria/snapshotstore"
 	"github.com/go-estoria/estoria/typeid"
 	"github.com/gofrs/uuid/v5"
@@ -33,6 +36,52 @@ func (m *mockSnapshotStore) WriteSnapshot(ctx context.Context, snapshot *snapsho
 	}
 
 	return errors.New("unexpected call to WriteSnapshot")
+}
+
+// emptyFilteredReadIsNotFoundStore wraps an event store with the read semantics of backing
+// stores that cannot distinguish an absent stream from a filtered read that matched nothing:
+// a forward read with an AfterVersion at or beyond the stream tip is reported as
+// ErrStreamNotFound. It counts those reads so a test can assert the case was exercised.
+type emptyFilteredReadIsNotFoundStore struct {
+	eventstore.Store
+	emptyFilteredReads int
+}
+
+func (s *emptyFilteredReadIsNotFoundStore) ReadStream(ctx context.Context, id typeid.ID, opts eventstore.ReadStreamOptions) (eventstore.StreamIterator, error) {
+	iter, err := s.Store.ReadStream(ctx, id, opts)
+	if err != nil {
+		return nil, err
+	}
+	defer iter.Close(ctx)
+
+	events, err := eventstore.ReadAll(ctx, iter)
+	if err != nil {
+		return nil, err
+	} else if len(events) == 0 {
+		s.emptyFilteredReads++
+		return nil, eventstore.ErrStreamNotFound
+	}
+
+	return &sliceStreamIterator{events: events}, nil
+}
+
+type sliceStreamIterator struct {
+	events []*eventstore.Event
+	cursor int
+}
+
+func (i *sliceStreamIterator) Next(_ context.Context) (*eventstore.Event, error) {
+	if i.cursor >= len(i.events) {
+		return nil, eventstore.ErrEndOfEventStream
+	}
+
+	event := i.events[i.cursor]
+	i.cursor++
+	return event, nil
+}
+
+func (i *sliceStreamIterator) Close(_ context.Context) error {
+	return nil
 }
 
 type mockSnapshotPolicy struct {
@@ -825,5 +874,108 @@ func TestSnapshottingStore_Save(t *testing.T) {
 				t.Errorf("want aggregate version %d, got %d", tt.wantAggregate.Version(), gotAggregate.Version())
 			}
 		})
+	}
+}
+
+// TestSnapshottingStore_LoadsAggregateSnapshottedAtStreamTip is a regression test for
+// https://github.com/go-estoria/estoria/issues/24: when a snapshot lands on exactly the
+// stream tip, hydrating from it leaves the inner store reading past the end of the stream.
+// Event stores that report such a read as ErrStreamNotFound made the aggregate look like it
+// did not exist, once every N events, until the next write moved the tip past the snapshot.
+func TestSnapshottingStore_LoadsAggregateSnapshottedAtStreamTip(t *testing.T) {
+	t.Parallel()
+
+	const snapshotEvery = 3
+
+	ctx := context.Background()
+	aggregateID := uuid.Must(uuid.NewV4())
+
+	eventStore, err := memory.NewEventStore()
+	if err != nil {
+		t.Fatalf("unexpected error creating event store: %v", err)
+	}
+
+	wrappedEventStore := &emptyFilteredReadIsNotFoundStore{Store: eventStore}
+
+	inner, err := aggregatestore.New(wrappedEventStore, newMockEntity,
+		aggregatestore.WithEventTypes(mockEntityEventA{}),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error creating inner store: %v", err)
+	}
+
+	var snapshot *snapshotstore.AggregateSnapshot
+
+	store, err := aggregatestore.NewSnapshottingStore[mockEntity](
+		inner,
+		&mockSnapshotStore{
+			ReadSnapshotFn: func(_ context.Context, _ typeid.ID, _ snapshotstore.ReadSnapshotOptions) (*snapshotstore.AggregateSnapshot, error) {
+				if snapshot == nil {
+					return nil, snapshotstore.ErrSnapshotNotFound
+				}
+
+				return snapshot, nil
+			},
+			WriteSnapshotFn: func(_ context.Context, snap *snapshotstore.AggregateSnapshot) error {
+				snapshot = snap
+				return nil
+			},
+		},
+		&mockSnapshotPolicy{
+			ShouldSnapshotFn: func(_ typeid.ID, version int64, _ time.Time) bool {
+				return version%snapshotEvery == 0
+			},
+		},
+		// round-trips the entity state that JSON cannot see, so that a load from a snapshot
+		// is distinguishable from a full replay of the stream
+		aggregatestore.WithSnapshotMarshaler[mockEntity](&mockSnapshotMarshaler{
+			MarshalFn: func(entity mockEntity) ([]byte, error) {
+				return []byte(strconv.FormatInt(entity.numAppliedEvents, 10)), nil
+			},
+			UnmarshalFn: func(data []byte, entity *mockEntity) error {
+				numAppliedEvents, err := strconv.ParseInt(string(data), 10, 64)
+				if err != nil {
+					return err
+				}
+
+				entity.numAppliedEvents = numAppliedEvents
+				return nil
+			},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error creating store: %v", err)
+	}
+
+	aggregate := store.New(aggregateID)
+
+	// save one event at a time, loading after each save, so the aggregate is read back at
+	// every version -- including the versions where a snapshot lands on the stream tip
+	for version := int64(1); version <= 2*snapshotEvery; version++ {
+		if err := aggregate.Append(mockEntityEventA{A: "a"}); err != nil {
+			t.Fatalf("unexpected error appending event at version %d: %v", version, err)
+		} else if err := store.Save(ctx, aggregate, nil); err != nil {
+			t.Fatalf("unexpected error saving aggregate at version %d: %v", version, err)
+		}
+
+		loaded, err := store.Load(ctx, aggregateID, nil)
+		if err != nil {
+			t.Fatalf("unexpected error loading aggregate at version %d: %v", version, err)
+		}
+
+		if loaded.Version() != version {
+			t.Errorf("want aggregate version %d, got %d", version, loaded.Version())
+		}
+
+		if got := loaded.Entity().numAppliedEvents; got != version {
+			t.Errorf("want %d applied events at version %d, got %d", version, version, got)
+		}
+	}
+
+	// the loads at versions 3 and 6 hydrate from a snapshot taken at the stream tip, leaving
+	// the inner store to read past the end of the stream; without those reads happening, the
+	// loads above would succeed whether or not the bug is fixed
+	if want := 2; wrappedEventStore.emptyFilteredReads != want {
+		t.Errorf("want %d empty filtered reads, got %d", want, wrappedEventStore.emptyFilteredReads)
 	}
 }

--- a/aggregatestore/snapshotting_store_test.go
+++ b/aggregatestore/snapshotting_store_test.go
@@ -50,13 +50,13 @@ type emptyFilteredReadIsNotFoundStore struct {
 func (s *emptyFilteredReadIsNotFoundStore) ReadStream(ctx context.Context, id typeid.ID, opts eventstore.ReadStreamOptions) (eventstore.StreamIterator, error) {
 	iter, err := s.Store.ReadStream(ctx, id, opts)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("reading stream: %w", err)
 	}
 	defer iter.Close(ctx)
 
 	events, err := eventstore.ReadAll(ctx, iter)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("reading events: %w", err)
 	} else if len(events) == 0 {
 		s.emptyFilteredReads++
 		return nil, eventstore.ErrStreamNotFound
@@ -935,7 +935,7 @@ func TestSnapshottingStore_LoadsAggregateSnapshottedAtStreamTip(t *testing.T) {
 			UnmarshalFn: func(data []byte, entity *mockEntity) error {
 				numAppliedEvents, err := strconv.ParseInt(string(data), 10, 64)
 				if err != nil {
-					return err
+					return fmt.Errorf("parsing applied event count: %w", err)
 				}
 
 				entity.numAppliedEvents = numAppliedEvents

--- a/eventstore/event_store.go
+++ b/eventstore/event_store.go
@@ -19,6 +19,15 @@ type Store interface {
 type StreamReader interface {
 	// ReadStream creates an event stream iterator for reading events from a stream.
 	// The starting point, direction, and number of events to read can be specified in the options.
+	//
+	// Implementations should return ErrStreamNotFound only when the stream itself does not
+	// exist. A stream that exists but has no events matching the options (for example a
+	// forward read with an AfterVersion at or beyond the stream's latest version) should
+	// yield an iterator that immediately reports ErrEndOfEventStream.
+	//
+	// Consumers should tolerate both. Distinguishing the two cases can cost an
+	// implementation an additional existence check, and some do not make it, so a
+	// filtered read reporting ErrStreamNotFound may mean either.
 	ReadStream(ctx context.Context, id typeid.ID, opts ReadStreamOptions) (StreamIterator, error)
 }
 
@@ -235,7 +244,8 @@ func (e EventExistsError) Is(target error) bool {
 	return ok
 }
 
-// ErrStreamNotFound is returned when an event stream is not found.
+// ErrStreamNotFound is returned when an event stream is not found. It signifies an absent
+// stream, not a read whose options matched no events; see StreamReader.ReadStream.
 var ErrStreamNotFound = errors.New("stream not found")
 
 // ErrStreamIteratorClosed is returned when an operation is attempted on a closed stream iterator.

--- a/eventstore/memory/event_store_test.go
+++ b/eventstore/memory/event_store_test.go
@@ -652,6 +652,26 @@ func TestEventStore_ReadStream(t *testing.T) {
 			},
 		},
 		{
+			// an existing stream with no events matching the options is not a missing
+			// stream; reporting it as one makes an aggregate at the stream tip unloadable
+			name: "returns an empty stream iterator for an existing stream read past its latest version",
+			haveEvents: []eventsForStream{
+				{
+					streamID: streamIDs[0],
+					events: []*eventstore.WritableEvent{
+						{Type: eventIDs[0].Type, Data: []byte("event 1 data")},
+						{Type: eventIDs[1].Type, Data: []byte("event 2 data")},
+						{Type: eventIDs[2].Type, Data: []byte("event 3 data")},
+					},
+				},
+			},
+			haveStreamID: streamIDs[0],
+			haveReadStreamOpts: eventstore.ReadStreamOptions{
+				AfterVersion: 3,
+			},
+			wantEvents: []*eventstore.Event{},
+		},
+		{
 			name:         "returns StreamNotFoundError for a non-existent stream",
 			haveStreamID: streamIDs[0],
 			wantErr:      eventstore.ErrStreamNotFound,


### PR DESCRIPTION
## Summary

A snapshot taken at exactly the stream tip made an aggregate permanently unloadable through a `SnapshottingStore`. `EventSourcedStore.Hydrate` treated `ErrStreamNotFound` from a filtered read as proof the aggregate does not exist, so once `SnapshottingStore.Hydrate` set the aggregate to a snapshot version equal to the tip, the inner store's `ReadStream(AfterVersion: tip)` came back not-found and every subsequent load failed with `ErrAggregateNotFound` — once every N events, healing only when the next write moved the tip.

Fixes #24.

## Approach

A read filtered by `AfterVersion` is not a reliable existence signal: it asks only for events newer than a version the aggregate has already reached. Existence is now decided by the aggregate's own state — an aggregate that already carries state (from a snapshot, or an earlier partial hydrate) exists, so an empty read past its version means there is nothing newer to apply. Only an unfiltered read can report absence, which is why an aggregate at version 0 still maps to `ErrAggregateNotFound`.

Fixing this in `EventSourcedStore` rather than only in contrib covers any event store that draws the same conclusion from an empty filtered read.

## Behavior change

`Hydrate` on an aggregate at version > 0 whose stream is genuinely absent now returns `nil`, leaving the aggregate at its current version, instead of `ErrAggregateNotFound`. Fresh loads, which read from version 0, are unaffected.

This is the one distinction the fix gives up: a conforming store would use `ErrStreamNotFound` on a filtered read only for a genuinely deleted stream, and that case now hydrates to the stale snapshot rather than reporting not-found.

## Contract

`StreamReader.ReadStream` now documents the convention — `ErrStreamNotFound` is for an absent stream, while a stream that exists but matches no events should yield an iterator that immediately reports `ErrEndOfEventStream`. Consumers should tolerate both, since distinguishing the two can cost an implementation an additional existence check and some do not make it.

## Tests

- End-to-end regression test driving a store with the contrib read semantics through two snapshot boundaries. It asserts the empty filtered reads actually happened, so it cannot pass vacuously.
- `Hydrate` cases with and without `ToVersion`.
- A memory store case locking in the documented convention. This is contract lock-in, not proof of the fix — the memory store never had the bug.

Verified non-vacuous: with the fix reverted, all three fail, the end-to-end one with the issue's exact `hydrating aggregate: aggregate not found` at version 3.

Unrelated to the fix: the `Hydrate` and `Save` table harnesses checked the store-construction error rather than the error under test on their success paths, so those cases could not fail. Both now check the right one, and no existing case broke.
