### PR TITLE
Fix correctness bugs in the aggregate and snapshot stores

### DIFF
--- a/aggregatestore/cached_store.go
+++ b/aggregatestore/cached_store.go
@@ -5,12 +5,16 @@ import (
 	"errors"
 
 	"github.com/go-estoria/estoria"
+	"github.com/go-estoria/estoria/typeid"
 	"github.com/gofrs/uuid/v5"
 )
 
 // An AggregateCache is a cache for aggregates.
+//
+// Aggregates are keyed by their typed ID rather than a bare UUID so that a cache backend
+// shared across aggregate types produces distinct, self-describing keys.
 type AggregateCache[E estoria.Entity] interface {
-	GetAggregate(ctx context.Context, aggregateID uuid.UUID) (*Aggregate[E], error)
+	GetAggregate(ctx context.Context, aggregateID typeid.ID) (*Aggregate[E], error)
 	PutAggregate(ctx context.Context, aggregate *Aggregate[E]) error
 }
 
@@ -26,8 +30,11 @@ func NewCachedStore[E estoria.Entity](
 	inner Store[E],
 	cacher AggregateCache[E],
 ) (*CachedStore[E], error) {
-	if inner == nil {
+	switch {
+	case inner == nil:
 		return nil, errors.New("inner store is required")
+	case cacher == nil:
+		return nil, errors.New("aggregate cache is required")
 	}
 
 	return &CachedStore[E]{
@@ -46,15 +53,32 @@ func (s *CachedStore[E]) New(id uuid.UUID) *Aggregate[E] {
 
 // Load loads an aggregate, first checking the cache before deferring to the inner store.
 // If the aggregate is loaded from the inner store, it is added to the cache.
+// A load for a specific version bypasses the cache entirely, in both directions. The cache
+// holds whatever version an aggregate was last saved or loaded at, which is not necessarily
+// the requested one, and writing a deliberately-truncated aggregate back would then serve
+// that stale version to subsequent full loads.
 func (s *CachedStore[E]) Load(ctx context.Context, id uuid.UUID, opts *LoadOptions) (*Aggregate[E], error) {
-	aggregate, err := s.cache.GetAggregate(ctx, id)
+	if opts != nil && opts.ToVersion > 0 {
+		s.log.Debug("bypassing cache for versioned load", "aggregate_id", id, "to_version", opts.ToVersion)
+
+		aggregate, err := s.inner.Load(ctx, id, opts)
+		if err != nil {
+			return nil, LoadError{Operation: "loading from inner aggregate store", Err: err}
+		}
+
+		return aggregate, nil
+	}
+
+	aggregateID := s.inner.New(id).ID()
+
+	aggregate, err := s.cache.GetAggregate(ctx, aggregateID)
 	switch {
 	case err == nil && aggregate != nil:
 		return aggregate, nil
 	case err != nil:
-		s.log.Warn("failed to read cache", "aggregate_id", id, "error", err)
+		s.log.Warn("failed to read cache", "aggregate_id", aggregateID, "error", err)
 	case aggregate == nil:
-		s.log.Debug("aggregate not in cache", "aggregate_id", id)
+		s.log.Debug("aggregate not in cache", "aggregate_id", aggregateID)
 	}
 
 	aggregate, err = s.inner.Load(ctx, id, opts)
@@ -63,7 +87,7 @@ func (s *CachedStore[E]) Load(ctx context.Context, id uuid.UUID, opts *LoadOptio
 	}
 
 	if err := s.cache.PutAggregate(ctx, aggregate); err != nil {
-		s.log.Warn("failed to write cache", "aggregate_id", id, "error", err)
+		s.log.Warn("failed to write cache", "aggregate_id", aggregateID, "error", err)
 	}
 
 	return aggregate, nil
@@ -76,12 +100,26 @@ func (s *CachedStore[E]) Hydrate(ctx context.Context, aggregate *Aggregate[E], o
 
 // Save saves an aggregate using the inner store, then updates the cache.
 func (s *CachedStore[E]) Save(ctx context.Context, aggregate *Aggregate[E], opts *SaveOptions) error {
+	if aggregate == nil {
+		return SaveError{Err: ErrNilAggregate}
+	}
+
 	if err := s.inner.Save(ctx, aggregate, opts); err != nil {
 		return SaveError{AggregateID: aggregate.ID(), Operation: "saving to inner aggregate store", Err: err}
 	}
 
+	// An aggregate saved with SkipApply still has events queued, so its entity and version
+	// trail what was just persisted. Caching it would serve that trailing state to later
+	// loads, so leave the previous entry alone and let the next load repopulate it.
+	if len(aggregate.state.unappliedEvents) > 0 {
+		s.log.Debug("skipping cache write for aggregate with unapplied events",
+			"aggregate_id", aggregate.ID(),
+			"unapplied_events", len(aggregate.state.unappliedEvents))
+		return nil
+	}
+
 	if err := s.cache.PutAggregate(ctx, aggregate); err != nil {
-		s.log.Warn("failed to write cache", "error", err)
+		s.log.Warn("failed to write cache", "aggregate_id", aggregate.ID(), "error", err)
 	}
 
 	return nil

--- a/aggregatestore/cached_store_test.go
+++ b/aggregatestore/cached_store_test.go
@@ -14,11 +14,13 @@ import (
 
 // mockCache is a mock implementation of aggregatestore.AggregateCache.
 type mockCache[E estoria.Entity] struct {
-	GetAggregateFn func(context.Context, uuid.UUID) (*aggregatestore.Aggregate[E], error)
+	GetAggregateFn func(context.Context, typeid.ID) (*aggregatestore.Aggregate[E], error)
 	PutAggregateFn func(context.Context, *aggregatestore.Aggregate[E]) error
 }
 
-func (c *mockCache[E]) GetAggregate(ctx context.Context, id uuid.UUID) (*aggregatestore.Aggregate[E], error) {
+var _ aggregatestore.AggregateCache[mockEntity] = (*mockCache[mockEntity])(nil)
+
+func (c *mockCache[E]) GetAggregate(ctx context.Context, id typeid.ID) (*aggregatestore.Aggregate[E], error) {
 	if c.GetAggregateFn != nil {
 		return c.GetAggregateFn(ctx, id)
 	}
@@ -96,8 +98,8 @@ func TestCachedStore_Load(t *testing.T) {
 			},
 			haveCache: func() aggregatestore.AggregateCache[mockEntity] {
 				return &mockCache[mockEntity]{
-					GetAggregateFn: func(_ context.Context, id uuid.UUID) (*aggregatestore.Aggregate[mockEntity], error) {
-						return aggregatestore.NewAggregate(newMockEntity(id), 42), nil
+					GetAggregateFn: func(_ context.Context, id typeid.ID) (*aggregatestore.Aggregate[mockEntity], error) {
+						return aggregatestore.NewAggregate(newMockEntity(id.UUID), 42), nil
 					},
 				}
 			},
@@ -119,7 +121,7 @@ func TestCachedStore_Load(t *testing.T) {
 			},
 			haveCache: func() aggregatestore.AggregateCache[mockEntity] {
 				return &mockCache[mockEntity]{
-					GetAggregateFn: func(context.Context, uuid.UUID) (*aggregatestore.Aggregate[mockEntity], error) {
+					GetAggregateFn: func(context.Context, typeid.ID) (*aggregatestore.Aggregate[mockEntity], error) {
 						return nil, nil
 					},
 				}
@@ -142,7 +144,7 @@ func TestCachedStore_Load(t *testing.T) {
 			},
 			haveCache: func() aggregatestore.AggregateCache[mockEntity] {
 				return &mockCache[mockEntity]{
-					GetAggregateFn: func(context.Context, uuid.UUID) (*aggregatestore.Aggregate[mockEntity], error) {
+					GetAggregateFn: func(context.Context, typeid.ID) (*aggregatestore.Aggregate[mockEntity], error) {
 						return nil, errors.New("mock error")
 					},
 				}
@@ -165,7 +167,7 @@ func TestCachedStore_Load(t *testing.T) {
 			},
 			haveCache: func() aggregatestore.AggregateCache[mockEntity] {
 				return &mockCache[mockEntity]{
-					GetAggregateFn: func(context.Context, uuid.UUID) (*aggregatestore.Aggregate[mockEntity], error) {
+					GetAggregateFn: func(context.Context, typeid.ID) (*aggregatestore.Aggregate[mockEntity], error) {
 						return nil, nil
 					},
 				}
@@ -425,5 +427,100 @@ func TestCachedStore_Save(t *testing.T) {
 				return
 			}
 		})
+	}
+}
+
+// TestNewCachedStore_RejectsNilCache guards against construction succeeding with no cache,
+// which deferred the failure to a nil-map panic on the first Load.
+func TestNewCachedStore_RejectsNilCache(t *testing.T) {
+	t.Parallel()
+
+	store, err := aggregatestore.NewCachedStore[mockEntity](&mockAggregateStore[mockEntity]{}, nil)
+	if err == nil {
+		t.Fatal("want an error constructing a cached store with a nil cache, got nil")
+	}
+	if store != nil {
+		t.Error("want a nil store alongside the error")
+	}
+}
+
+// TestCachedStore_Load_BypassesCacheForVersionedLoad guards against a cache hit short-
+// circuiting a load that asked for a specific version. The cache holds whatever version was
+// last saved, so serving it for a ToVersion load silently returns the wrong state.
+//
+// The cache must also not be written on this path: storing a deliberately-truncated
+// aggregate would serve that stale version to later full loads.
+func TestCachedStore_Load_BypassesCacheForVersionedLoad(t *testing.T) {
+	t.Parallel()
+
+	aggregateID := uuid.Must(uuid.NewV4())
+
+	var cacheReads, cacheWrites int
+
+	inner := &mockAggregateStore[mockEntity]{
+		NewFn: func(id uuid.UUID) *aggregatestore.Aggregate[mockEntity] {
+			return aggregatestore.NewAggregate(newMockEntity(id), 0)
+		},
+		LoadFn: func(_ context.Context, id uuid.UUID, opts *aggregatestore.LoadOptions) (*aggregatestore.Aggregate[mockEntity], error) {
+			if opts == nil || opts.ToVersion == 0 {
+				return aggregatestore.NewAggregate(newMockEntity(id), 10), nil
+			}
+			return aggregatestore.NewAggregate(newMockEntity(id), opts.ToVersion), nil
+		},
+	}
+
+	cache := &mockCache[mockEntity]{
+		GetAggregateFn: func(_ context.Context, id typeid.ID) (*aggregatestore.Aggregate[mockEntity], error) {
+			cacheReads++
+			return aggregatestore.NewAggregate(newMockEntity(id.UUID), 10), nil
+		},
+		PutAggregateFn: func(context.Context, *aggregatestore.Aggregate[mockEntity]) error {
+			cacheWrites++
+			return nil
+		},
+	}
+
+	store, err := aggregatestore.NewCachedStore[mockEntity](inner, cache)
+	if err != nil {
+		t.Fatalf("creating cached store: %v", err)
+	}
+
+	got, err := store.Load(t.Context(), aggregateID, &aggregatestore.LoadOptions{ToVersion: 3})
+	if err != nil {
+		t.Fatalf("loading aggregate: %v", err)
+	}
+
+	if want := int64(3); got.Version() != want {
+		t.Errorf("want version %d from a versioned load, got %d", want, got.Version())
+	}
+	if cacheReads != 0 {
+		t.Errorf("want the cache not read for a versioned load, got %d reads", cacheReads)
+	}
+	if cacheWrites != 0 {
+		t.Errorf("want the cache not written for a versioned load, got %d writes", cacheWrites)
+	}
+
+	// An unversioned load still uses the cache.
+	if _, err := store.Load(t.Context(), aggregateID, nil); err != nil {
+		t.Fatalf("loading aggregate without options: %v", err)
+	}
+	if cacheReads != 1 {
+		t.Errorf("want 1 cache read for an unversioned load, got %d", cacheReads)
+	}
+}
+
+// TestCachedStore_Save_NilAggregate guards against Save dereferencing a nil aggregate,
+// where every other store in this package returns ErrNilAggregate.
+func TestCachedStore_Save_NilAggregate(t *testing.T) {
+	t.Parallel()
+
+	store, err := aggregatestore.NewCachedStore[mockEntity](
+		&mockAggregateStore[mockEntity]{}, &mockCache[mockEntity]{})
+	if err != nil {
+		t.Fatalf("creating cached store: %v", err)
+	}
+
+	if err := store.Save(t.Context(), nil, nil); !errors.Is(err, aggregatestore.ErrNilAggregate) {
+		t.Errorf("want ErrNilAggregate, got %v", err)
 	}
 }

--- a/aggregatestore/event_sourced_store_test.go
+++ b/aggregatestore/event_sourced_store_test.go
@@ -253,16 +253,12 @@ func (m mockStreamWriter) AppendStream(_ context.Context, _ typeid.ID, _ []*even
 }
 
 type mockStreamIterator struct {
-	allEvents []*eventstore.Event
-	allErr    error
 	nextEvent *eventstore.Event
 	nextErr   error
 	closeErr  error
 }
 
-func (m mockStreamIterator) All(_ context.Context) ([]*eventstore.Event, error) {
-	return m.allEvents, m.allErr
-}
+var _ eventstore.StreamIterator = mockStreamIterator{}
 
 func (m mockStreamIterator) Next(_ context.Context) (*eventstore.Event, error) {
 	return m.nextEvent, m.nextErr

--- a/aggregatestore/hookable_store.go
+++ b/aggregatestore/hookable_store.go
@@ -110,6 +110,10 @@ func (s *HookableStore[E]) Load(ctx context.Context, id uuid.UUID, opts *LoadOpt
 
 // Hydrate hydrates an aggregate, executing any pre- and post-hydrate hooks.
 func (s *HookableStore[E]) Hydrate(ctx context.Context, aggregate *Aggregate[E], opts *HydrateOptions) error {
+	if aggregate == nil {
+		return HydrateError{Err: ErrNilAggregate}
+	}
+
 	s.log.Debug("hydrating aggregate", "aggregate_id", aggregate.ID())
 	for _, hook := range s.hooks[BeforeHydrate] {
 		if err := hook(ctx, aggregate); err != nil {
@@ -132,6 +136,10 @@ func (s *HookableStore[E]) Hydrate(ctx context.Context, aggregate *Aggregate[E],
 
 // Save saves an aggregate, executing any pre- and post-save hooks.
 func (s *HookableStore[E]) Save(ctx context.Context, aggregate *Aggregate[E], opts *SaveOptions) error {
+	if aggregate == nil {
+		return SaveError{Err: ErrNilAggregate}
+	}
+
 	s.log.Debug("saving aggregate", "aggregate_id", aggregate.ID())
 	for _, hook := range s.hooks[BeforeSave] {
 		if err := hook(ctx, aggregate); err != nil {

--- a/aggregatestore/snapshotting_store.go
+++ b/aggregatestore/snapshotting_store.go
@@ -128,9 +128,15 @@ func (s *SnapshottingStore[E]) Hydrate(ctx context.Context, aggregate *Aggregate
 		return s.inner.Hydrate(ctx, aggregate, opts)
 	}
 
-	entity := aggregate.Entity()
+	// Decode into a fresh entity rather than the aggregate's live one. When E is a
+	// pointer type the marshaler writes through to the entity in place, so a snapshot
+	// that is valid JSON but disagrees on a field's type — ordinary schema drift —
+	// applies the fields it can before failing. Decoding into the live entity would
+	// leave that partial state behind and then replay events on top of it, silently
+	// returning a corrupt aggregate with a nil error.
+	entity := s.inner.New(aggregate.ID().UUID).Entity()
 	if err := s.marshaler.UnmarshalEntity(snap.Data, &entity); err != nil {
-		log.Warn("failed to unmarshal snapshot", "error", err)
+		log.Warn("failed to unmarshal snapshot, falling back to full hydration", "error", err)
 		return s.inner.Hydrate(ctx, aggregate, opts)
 	}
 
@@ -154,14 +160,17 @@ func (s *SnapshottingStore[E]) Save(ctx context.Context, aggregate *Aggregate[E]
 
 	log.Debug("saving aggregate")
 
-	if opts == nil {
-		opts = &SaveOptions{}
+	// Defer applying events so a snapshot can be taken at an exact version.
+	// This is set on a copy: opts belongs to the caller, and mutating it would
+	// leak SkipApply into every later save that reuses the same struct.
+	innerOpts := SaveOptions{}
+	if opts != nil {
+		innerOpts = *opts
 	}
 
-	// defer applying events so a snapshot can be taken at an exact version
-	opts.SkipApply = true
+	innerOpts.SkipApply = true
 
-	if err := s.inner.Save(ctx, aggregate, opts); err != nil {
+	if err := s.inner.Save(ctx, aggregate, &innerOpts); err != nil {
 		return SaveError{AggregateID: aggregate.ID(), Operation: "saving aggregate using inner store", Err: err}
 	}
 

--- a/aggregatestore/snapshotting_store_test.go
+++ b/aggregatestore/snapshotting_store_test.go
@@ -979,3 +979,171 @@ func TestSnapshottingStore_LoadsAggregateSnapshottedAtStreamTip(t *testing.T) {
 		t.Errorf("want %d empty filtered reads, got %d", want, wrappedEventStore.emptyFilteredReads)
 	}
 }
+
+// mockPointerEntity is a pointer-typed entity. The rest of this suite uses the value-typed
+// mockEntity, which is why the in-place snapshot corruption below went unnoticed: a marshaler
+// writing through *E only touches the aggregate's live entity when E is a pointer.
+type mockPointerEntity struct {
+	ID typeid.ID `json:"id"`
+	// Balance is advanced by events.
+	Balance int `json:"balance"`
+	// Owner is only ever set by a snapshot, never by an event, so any value here after a
+	// failed snapshot load is state that leaked out of a partial unmarshal.
+	Owner string `json:"owner"`
+}
+
+var _ estoria.Entity = (*mockPointerEntity)(nil)
+
+func newMockPointerEntity(id uuid.UUID) *mockPointerEntity {
+	return &mockPointerEntity{ID: typeid.New("mockpointerentity", id)}
+}
+
+func (e *mockPointerEntity) EntityID() typeid.ID { return e.ID }
+
+type mockPointerEntityEvent struct {
+	Amount int `json:"amount"`
+}
+
+func (e *mockPointerEntityEvent) EventType() string { return "credited" }
+
+func (e *mockPointerEntityEvent) New() estoria.EntityEvent[*mockPointerEntity] {
+	return &mockPointerEntityEvent{}
+}
+
+func (e *mockPointerEntityEvent) ApplyTo(_ context.Context, entity *mockPointerEntity) (*mockPointerEntity, error) {
+	entity.Balance += e.Amount
+	return entity, nil
+}
+
+// TestSnapshottingStore_Save_DoesNotMutateCallerOptions guards against Save setting
+// SkipApply on the caller's own SaveOptions. Leaking it meant the next save that reused the
+// struct silently skipped applying events, leaving the aggregate's in-memory version stale,
+// which surfaced one save later as a spurious StreamVersionMismatchError.
+func TestSnapshottingStore_Save_DoesNotMutateCallerOptions(t *testing.T) {
+	t.Parallel()
+
+	eventStore, err := memory.NewEventStore()
+	if err != nil {
+		t.Fatalf("creating event store: %v", err)
+	}
+
+	inner, err := aggregatestore.New[mockEntity](eventStore, newMockEntity,
+		aggregatestore.WithEventTypes[mockEntity](&mockEntityEventA{}))
+	if err != nil {
+		t.Fatalf("creating inner store: %v", err)
+	}
+
+	snapshotting, err := aggregatestore.NewSnapshottingStore[mockEntity](
+		inner,
+		&mockSnapshotStore{
+			WriteSnapshotFn: func(context.Context, *snapshotstore.AggregateSnapshot) error { return nil },
+		},
+		&mockSnapshotPolicy{ShouldSnapshotFn: func(typeid.ID, int64, time.Time) bool { return false }},
+	)
+	if err != nil {
+		t.Fatalf("creating snapshotting store: %v", err)
+	}
+
+	opts := &aggregatestore.SaveOptions{}
+
+	first := snapshotting.New(uuid.Must(uuid.NewV4()))
+	if err := first.Append(&mockEntityEventA{}); err != nil {
+		t.Fatalf("appending event: %v", err)
+	}
+	if err := snapshotting.Save(t.Context(), first, opts); err != nil {
+		t.Fatalf("saving through snapshotting store: %v", err)
+	}
+
+	if opts.SkipApply {
+		t.Error("Save mutated the caller's SaveOptions: want SkipApply false, got true")
+	}
+
+	// Reusing the same options on another store must still apply events.
+	second := inner.New(uuid.Must(uuid.NewV4()))
+	if err := second.Append(&mockEntityEventA{}); err != nil {
+		t.Fatalf("appending event: %v", err)
+	}
+	if err := inner.Save(t.Context(), second, opts); err != nil {
+		t.Fatalf("saving through inner store: %v", err)
+	}
+
+	if want := int64(1); second.Version() != want {
+		t.Errorf("want version %d after reusing options, got %d", want, second.Version())
+	}
+
+	// The stale version is what produced the spurious conflict, so save once more.
+	if err := second.Append(&mockEntityEventA{}); err != nil {
+		t.Fatalf("appending event: %v", err)
+	}
+	if err := inner.Save(t.Context(), second, &aggregatestore.SaveOptions{}); err != nil {
+		t.Errorf("unexpected error on subsequent save: %v", err)
+	}
+}
+
+// TestSnapshottingStore_Hydrate_PartialSnapshotDoesNotCorruptEntity guards against a
+// snapshot that is syntactically valid JSON but disagrees on a field's type — ordinary
+// schema drift — writing the fields it can into the aggregate's live entity before failing.
+// The store falls back to full hydration on unmarshal failure, so any leaked state would be
+// replayed on top of and returned with a nil error.
+//
+// Note: truncated JSON does NOT reproduce this. encoding/json validates the whole document
+// before writing, so the payload has to parse cleanly and fail on a type mismatch.
+func TestSnapshottingStore_Hydrate_PartialSnapshotDoesNotCorruptEntity(t *testing.T) {
+	t.Parallel()
+
+	eventStore, err := memory.NewEventStore()
+	if err != nil {
+		t.Fatalf("creating event store: %v", err)
+	}
+
+	inner, err := aggregatestore.New[*mockPointerEntity](eventStore, newMockPointerEntity,
+		aggregatestore.WithEventTypes[*mockPointerEntity](&mockPointerEntityEvent{}))
+	if err != nil {
+		t.Fatalf("creating inner store: %v", err)
+	}
+
+	// Seed a stream: three credits of one each.
+	id := uuid.Must(uuid.NewV4())
+	seed := inner.New(id)
+	for range 3 {
+		if err := seed.Append(&mockPointerEntityEvent{Amount: 1}); err != nil {
+			t.Fatalf("appending event: %v", err)
+		}
+	}
+	if err := inner.Save(t.Context(), seed, nil); err != nil {
+		t.Fatalf("seeding stream: %v", err)
+	}
+
+	snapshotting, err := aggregatestore.NewSnapshottingStore[*mockPointerEntity](
+		inner,
+		&mockSnapshotStore{
+			ReadSnapshotFn: func(_ context.Context, aggregateID typeid.ID, _ snapshotstore.ReadSnapshotOptions) (*snapshotstore.AggregateSnapshot, error) {
+				return &snapshotstore.AggregateSnapshot{
+					AggregateID:      aggregateID,
+					AggregateVersion: 2,
+					// Parses cleanly; owner lands, then balance fails on type.
+					Data: []byte(`{"owner":"corrupted","balance":"9999"}`),
+				}, nil
+			},
+		},
+		&mockSnapshotPolicy{ShouldSnapshotFn: func(typeid.ID, int64, time.Time) bool { return false }},
+	)
+	if err != nil {
+		t.Fatalf("creating snapshotting store: %v", err)
+	}
+
+	got, err := snapshotting.Load(t.Context(), id, nil)
+	if err != nil {
+		t.Fatalf("loading aggregate: %v", err)
+	}
+
+	if want := int64(3); got.Version() != want {
+		t.Errorf("want version %d, got %d", want, got.Version())
+	}
+	if want := 3; got.Entity().Balance != want {
+		t.Errorf("want balance %d, got %d", want, got.Entity().Balance)
+	}
+	if owner := got.Entity().Owner; owner != "" {
+		t.Errorf("state leaked from a failed snapshot unmarshal: want empty owner, got %q", owner)
+	}
+}

--- a/snapshotstore/eventstream/event_stream_store.go
+++ b/snapshotstore/eventstream/event_stream_store.go
@@ -30,40 +30,66 @@ func NewEventStreamStore(eventStore eventstore.Store) *EventStreamStore {
 	}
 }
 
-func (s *EventStreamStore) ReadSnapshot(ctx context.Context, aggregateID typeid.ID, _ snapshotstore.ReadSnapshotOptions) (*snapshotstore.AggregateSnapshot, error) {
-	estoria.GetLogger().Debug("finding snapshot", "aggregate_id", aggregateID)
+// ReadSnapshot returns the most recent snapshot for an aggregate, or the most recent one at
+// or below opts.MaxVersion when that is set.
+//
+// Snapshots live as events in a parallel stream, and a snapshot event's stream version is
+// unrelated to the aggregate version it captures, so a bounded read walks the stream
+// backwards until it finds a snapshot within the bound. An unbounded read only ever needs
+// the newest event.
+func (s *EventStreamStore) ReadSnapshot(ctx context.Context, aggregateID typeid.ID, opts snapshotstore.ReadSnapshotOptions) (*snapshotstore.AggregateSnapshot, error) {
+	estoria.GetLogger().Debug("finding snapshot", "aggregate_id", aggregateID, "max_version", opts.MaxVersion)
 
 	snapshotStreamID := typeid.New(aggregateID.Type+"snapshot", aggregateID.UUID)
 
-	stream, err := s.eventReader.ReadStream(ctx, snapshotStreamID, eventstore.ReadStreamOptions{
+	readOpts := eventstore.ReadStreamOptions{
 		AfterVersion: 0,
-		Count:        1,
 		Direction:    eventstore.Reverse,
-	})
-	if err != nil {
+	}
+
+	if opts.MaxVersion <= 0 {
+		readOpts.Count = 1
+	}
+
+	stream, err := s.eventReader.ReadStream(ctx, snapshotStreamID, readOpts)
+	if errors.Is(err, eventstore.ErrStreamNotFound) {
+		// An aggregate that has never been snapshotted has no snapshot stream. That is the
+		// ordinary case on a first load, not a failure, so it maps to ErrSnapshotNotFound —
+		// which is what SnapshottingStore checks before falling back to full hydration.
+		return nil, snapshotstore.ErrSnapshotNotFound
+	} else if err != nil {
 		return nil, fmt.Errorf("finding snapshot stream: %w", err)
 	}
 
-	event, err := stream.Next(ctx)
-	switch {
-	case errors.Is(err, eventstore.ErrEndOfEventStream):
-		return nil, snapshotstore.ErrSnapshotNotFound
-	case err != nil:
-		return nil, fmt.Errorf("reading snapshot event: %w", err)
-	case event == nil:
-		return nil, errors.New("snapshot event not found")
+	defer stream.Close(ctx)
+
+	for {
+		event, err := stream.Next(ctx)
+		switch {
+		case errors.Is(err, eventstore.ErrEndOfEventStream):
+			return nil, snapshotstore.ErrSnapshotNotFound
+		case err != nil:
+			return nil, fmt.Errorf("reading snapshot event: %w", err)
+		case event == nil:
+			return nil, errors.New("snapshot event not found")
+		}
+
+		var snapshot snapshotstore.AggregateSnapshot
+		if err := s.marshaler.UnmarshalSnapshot(event.Data, &snapshot); err != nil {
+			return nil, fmt.Errorf("unmarshaling snapshot: %w", err)
+		}
+
+		if opts.MaxVersion > 0 && snapshot.AggregateVersion > opts.MaxVersion {
+			continue
+		}
+
+		estoria.GetLogger().Debug("snapshot event found",
+			"stream_id", snapshotStreamID,
+			"stream_version", event.StreamVersion,
+			"aggregate_version", snapshot.AggregateVersion)
+
+		return &snapshot, nil
 	}
-
-	estoria.GetLogger().Debug("snapshot event found",
-		"stream_id", snapshotStreamID,
-		"stream_version", event.StreamVersion)
-
-	var snapshot snapshotstore.AggregateSnapshot
-	if err := s.marshaler.UnmarshalSnapshot(event.Data, &snapshot); err != nil {
-		return nil, fmt.Errorf("unmarshaling snapshot: %w", err)
-	}
-
-	return &snapshot, nil
 }
 
 func (s *EventStreamStore) WriteSnapshot(ctx context.Context, snap *snapshotstore.AggregateSnapshot) error {

--- a/snapshotstore/eventstream/event_stream_store_test.go
+++ b/snapshotstore/eventstream/event_stream_store_test.go
@@ -1,0 +1,250 @@
+// Package snapshotstore_test exercises the event-stream-backed snapshot store.
+//
+// Note the package name does not match its directory (`eventstream`), so importers must
+// alias it. Renaming is deferred to the Phase 3 distillation pass.
+package snapshotstore_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/go-estoria/estoria"
+	"github.com/go-estoria/estoria/aggregatestore"
+	"github.com/go-estoria/estoria/eventstore"
+	"github.com/go-estoria/estoria/eventstore/memory"
+	"github.com/go-estoria/estoria/snapshotstore"
+	eventstream "github.com/go-estoria/estoria/snapshotstore/eventstream"
+	"github.com/go-estoria/estoria/typeid"
+	"github.com/gofrs/uuid/v5"
+)
+
+var _ snapshotstore.SnapshotStore = (*eventstream.EventStreamStore)(nil)
+
+// closeCountingStore counts the iterators handed out and the ones closed, so a test can
+// assert the snapshot store does not leak cursors. Against a real backend a leaked iterator
+// is an open rows handle or server-side cursor.
+type closeCountingStore struct {
+	eventstore.Store
+	opened int
+	closed int
+}
+
+func (s *closeCountingStore) ReadStream(ctx context.Context, id typeid.ID, opts eventstore.ReadStreamOptions) (eventstore.StreamIterator, error) {
+	iter, err := s.Store.ReadStream(ctx, id, opts)
+	if err != nil {
+		return nil, err //nolint:wrapcheck // pass the sentinel through unchanged
+	}
+
+	s.opened++
+	return &closeCountingIterator{StreamIterator: iter, store: s}, nil
+}
+
+type closeCountingIterator struct {
+	eventstore.StreamIterator
+	store *closeCountingStore
+}
+
+func (i *closeCountingIterator) Close(ctx context.Context) error {
+	i.store.closed++
+	return i.StreamIterator.Close(ctx) //nolint:wrapcheck // pass through unchanged
+}
+
+func newStore(t *testing.T) (*eventstream.EventStreamStore, *closeCountingStore) {
+	t.Helper()
+
+	eventStore, err := memory.NewEventStore()
+	if err != nil {
+		t.Fatalf("creating event store: %v", err)
+	}
+
+	counting := &closeCountingStore{Store: eventStore}
+	return eventstream.NewEventStreamStore(counting), counting
+}
+
+func writeSnapshots(t *testing.T, store *eventstream.EventStreamStore, aggregateID typeid.ID, versions ...int64) {
+	t.Helper()
+
+	for _, version := range versions {
+		if err := store.WriteSnapshot(t.Context(), &snapshotstore.AggregateSnapshot{
+			AggregateID:      aggregateID,
+			AggregateVersion: version,
+			Data:             []byte(`{"n":1}`),
+		}); err != nil {
+			t.Fatalf("writing snapshot at version %d: %v", version, err)
+		}
+	}
+}
+
+// TestReadSnapshot_AbsentStreamIsSnapshotNotFound guards against a never-snapshotted
+// aggregate surfacing as a wrapped ErrStreamNotFound. SnapshottingStore checks for
+// ErrSnapshotNotFound before falling back to full hydration, so anything else took the
+// "failed to read snapshot" branch and logged a warning on every first load.
+func TestReadSnapshot_AbsentStreamIsSnapshotNotFound(t *testing.T) {
+	t.Parallel()
+
+	store, _ := newStore(t)
+
+	_, err := store.ReadSnapshot(t.Context(), typeid.NewV4("mockentity"), snapshotstore.ReadSnapshotOptions{})
+	if !errors.Is(err, snapshotstore.ErrSnapshotNotFound) {
+		t.Errorf("want ErrSnapshotNotFound, got %v", err)
+	}
+	if errors.Is(err, eventstore.ErrStreamNotFound) {
+		t.Error("want the event-store sentinel translated, got a bare ErrStreamNotFound")
+	}
+}
+
+// TestReadSnapshot_HonorsMaxVersion guards against opts being ignored. Returning the newest
+// snapshot regardless of the bound made every ToVersion load fail outright: the aggregate
+// was set past the target, and the inner store then rejected it as "more recent than
+// requested".
+func TestReadSnapshot_HonorsMaxVersion(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name        string
+		maxVersion  int64
+		wantVersion int64
+		wantErr     error
+	}{
+		{name: "unbounded read returns the newest snapshot", maxVersion: 0, wantVersion: 10},
+		{name: "exact match returns that snapshot", maxVersion: 5, wantVersion: 5},
+		{name: "no exact match returns the newest below the bound", maxVersion: 7, wantVersion: 6},
+		{name: "bound at the newest returns the newest", maxVersion: 10, wantVersion: 10},
+		{name: "bound below every snapshot reports not found", maxVersion: 1, wantErr: snapshotstore.ErrSnapshotNotFound},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			store, _ := newStore(t)
+			aggregateID := typeid.NewV4("mockentity")
+			writeSnapshots(t, store, aggregateID, 2, 4, 5, 6, 10)
+
+			snap, err := store.ReadSnapshot(t.Context(), aggregateID,
+				snapshotstore.ReadSnapshotOptions{MaxVersion: tt.maxVersion})
+
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Errorf("want %v, got %v", tt.wantErr, err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("reading snapshot: %v", err)
+			}
+			if snap.AggregateVersion != tt.wantVersion {
+				t.Errorf("want aggregate version %d, got %d", tt.wantVersion, snap.AggregateVersion)
+			}
+		})
+	}
+}
+
+// TestReadSnapshot_ClosesIterator guards against the read leaking a cursor on every call.
+func TestReadSnapshot_ClosesIterator(t *testing.T) {
+	t.Parallel()
+
+	store, counting := newStore(t)
+	aggregateID := typeid.NewV4("mockentity")
+	writeSnapshots(t, store, aggregateID, 1, 2, 3)
+
+	if _, err := store.ReadSnapshot(t.Context(), aggregateID, snapshotstore.ReadSnapshotOptions{}); err != nil {
+		t.Fatalf("reading snapshot: %v", err)
+	}
+	if _, err := store.ReadSnapshot(t.Context(), aggregateID, snapshotstore.ReadSnapshotOptions{MaxVersion: 2}); err != nil {
+		t.Fatalf("reading bounded snapshot: %v", err)
+	}
+
+	if counting.opened == 0 {
+		t.Fatal("expected the store to open at least one iterator")
+	}
+	if counting.closed != counting.opened {
+		t.Errorf("leaked iterators: opened %d, closed %d", counting.opened, counting.closed)
+	}
+}
+
+type mockEntity struct {
+	ID    typeid.ID `json:"id"`
+	Count int       `json:"count"`
+}
+
+func (e *mockEntity) EntityID() typeid.ID { return e.ID }
+
+func newMockEntity(id uuid.UUID) *mockEntity {
+	return &mockEntity{ID: typeid.New("mockentity", id)}
+}
+
+type mockEntityEvent struct{}
+
+func (e *mockEntityEvent) EventType() string { return "incremented" }
+
+func (e *mockEntityEvent) New() estoria.EntityEvent[*mockEntity] { return &mockEntityEvent{} }
+
+func (e *mockEntityEvent) ApplyTo(_ context.Context, entity *mockEntity) (*mockEntity, error) {
+	entity.Count++
+	return entity, nil
+}
+
+// TestSnapshottingStore_VersionedLoad exercises the symptom that made the ignored MaxVersion
+// worth fixing: a versioned load through a SnapshottingStore backed by this store failed
+// outright, because the newest snapshot was applied past the requested version and the inner
+// store then rejected the aggregate as more recent than requested.
+func TestSnapshottingStore_VersionedLoad(t *testing.T) {
+	t.Parallel()
+
+	eventStore, err := memory.NewEventStore()
+	if err != nil {
+		t.Fatalf("creating event store: %v", err)
+	}
+
+	inner, err := aggregatestore.New[*mockEntity](eventStore, newMockEntity,
+		aggregatestore.WithEventTypes[*mockEntity](&mockEntityEvent{}))
+	if err != nil {
+		t.Fatalf("creating inner store: %v", err)
+	}
+
+	// Snapshot on every event, so a snapshot exists at each version including the tip.
+	store, err := aggregatestore.NewSnapshottingStore[*mockEntity](
+		inner,
+		eventstream.NewEventStreamStore(eventStore),
+		snapshotstore.EventCountSnapshotPolicy{N: 1},
+	)
+	if err != nil {
+		t.Fatalf("creating snapshotting store: %v", err)
+	}
+
+	id := uuid.Must(uuid.NewV4())
+	aggregate := store.New(id)
+	for range 10 {
+		if err := aggregate.Append(&mockEntityEvent{}); err != nil {
+			t.Fatalf("appending event: %v", err)
+		}
+	}
+	if err := store.Save(t.Context(), aggregate, nil); err != nil {
+		t.Fatalf("saving aggregate: %v", err)
+	}
+
+	for _, wantVersion := range []int64{1, 3, 7, 10} {
+		got, err := store.Load(t.Context(), id, &aggregatestore.LoadOptions{ToVersion: wantVersion})
+		if err != nil {
+			t.Errorf("loading to version %d: %v", wantVersion, err)
+			continue
+		}
+
+		if got.Version() != wantVersion {
+			t.Errorf("want version %d, got %d", wantVersion, got.Version())
+		}
+		if got.Entity().Count != int(wantVersion) {
+			t.Errorf("want count %d at version %d, got %d", wantVersion, wantVersion, got.Entity().Count)
+		}
+	}
+
+	// An unbounded load still reaches the tip.
+	got, err := store.Load(t.Context(), id, nil)
+	if err != nil {
+		t.Fatalf("loading latest: %v", err)
+	}
+	if want := int64(10); got.Version() != want {
+		t.Errorf("want version %d for an unbounded load, got %d", want, got.Version())
+	}
+}

--- a/snapshotstore/memory/snapshot_store.go
+++ b/snapshotstore/memory/snapshot_store.go
@@ -2,8 +2,8 @@ package memory
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
+	"sync"
 
 	"github.com/go-estoria/estoria"
 	"github.com/go-estoria/estoria/snapshotstore"
@@ -23,20 +23,22 @@ type SnapshotMarshaler interface {
 
 type SnapshotStore struct {
 	snapshots map[typeid.ID][]*snapshotstore.AggregateSnapshot
-	marshaler SnapshotMarshaler
+	mu        sync.RWMutex
 	retention RetentionPolicy
 }
 
 func NewSnapshotStore() *SnapshotStore {
 	return &SnapshotStore{
 		snapshots: map[typeid.ID][]*snapshotstore.AggregateSnapshot{},
-		marshaler: snapshotstore.JSONSnapshotMarshaler{},
 		retention: snapshotstore.MaxSnapshotsRetentionPolicy{N: 1},
 	}
 }
 
 func (s *SnapshotStore) ReadSnapshot(_ context.Context, aggregateID typeid.ID, opts snapshotstore.ReadSnapshotOptions) (*snapshotstore.AggregateSnapshot, error) {
 	estoria.GetLogger().Debug("finding snapshot", "aggregate_id", aggregateID)
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 
 	snapshots, ok := s.snapshots[aggregateID]
 	if !ok || len(snapshots) == 0 {
@@ -66,11 +68,10 @@ func (s *SnapshotStore) WriteSnapshot(_ context.Context, snap *snapshotstore.Agg
 		snap.AggregateVersion,
 		"data_length", len(snap.Data))
 
-	snapshots, ok := s.snapshots[snap.AggregateID]
-	if !ok {
-		s.snapshots[snap.AggregateID] = []*snapshotstore.AggregateSnapshot{}
-		snapshots = s.snapshots[snap.AggregateID]
-	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	snapshots := s.snapshots[snap.AggregateID]
 
 	if len(snapshots) > 0 {
 		if snap.AggregateVersion <= snapshots[len(snapshots)-1].AggregateVersion {
@@ -78,16 +79,18 @@ func (s *SnapshotStore) WriteSnapshot(_ context.Context, snap *snapshotstore.Agg
 		}
 	}
 
-	s.snapshots[snap.AggregateID] = append(s.snapshots[snap.AggregateID], snap)
+	snapshots = append(snapshots, snap)
 
-	retained := []*snapshotstore.AggregateSnapshot{}
-	for i, snap := range s.snapshots[snap.AggregateID] {
-		if !s.retention.ShouldRetain(snap, int64(i), int64(len(s.snapshots[snap.AggregateID]))) {
-			estoria.GetLogger().Debug("deleting snapshot per retention policy", "aggregate_id", snap.AggregateID, "aggregate_version", snap.AggregateVersion)
+	retained := make([]*snapshotstore.AggregateSnapshot, 0, len(snapshots))
+	for i, candidate := range snapshots {
+		if !s.retention.ShouldRetain(candidate, int64(i), int64(len(snapshots))) {
+			estoria.GetLogger().Debug("deleting snapshot per retention policy",
+				"aggregate_id", candidate.AggregateID,
+				"aggregate_version", candidate.AggregateVersion)
 			continue
 		}
 
-		retained = append(retained, snap)
+		retained = append(retained, candidate)
 	}
 
 	s.snapshots[snap.AggregateID] = retained
@@ -95,14 +98,4 @@ func (s *SnapshotStore) WriteSnapshot(_ context.Context, snap *snapshotstore.Agg
 	estoria.GetLogger().Debug("wrote snapshot", "aggregate_id", snap.AggregateID, "aggregate_version", snap.AggregateVersion)
 
 	return nil
-}
-
-type JSONSnapshotMarshaler struct{}
-
-func (m JSONSnapshotMarshaler) MarshalSnapshot(snap *snapshotstore.AggregateSnapshot) ([]byte, error) {
-	return json.Marshal(snap)
-}
-
-func (m JSONSnapshotMarshaler) UnmarshalSnapshot(data []byte, dest *snapshotstore.AggregateSnapshot) error {
-	return json.Unmarshal(data, dest)
 }

--- a/snapshotstore/memory/snapshot_store_test.go
+++ b/snapshotstore/memory/snapshot_store_test.go
@@ -1,0 +1,145 @@
+package memory_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/go-estoria/estoria/snapshotstore"
+	"github.com/go-estoria/estoria/snapshotstore/memory"
+	"github.com/go-estoria/estoria/typeid"
+)
+
+var _ snapshotstore.SnapshotStore = (*memory.SnapshotStore)(nil)
+
+// TestSnapshotStore_ConcurrentReadWrite guards against the store's map being accessed
+// without synchronization. The sibling eventstore/memory has always held a mutex; this one
+// did not, so any concurrent reader and writer raced. Meaningful only under -race, which CI
+// runs.
+func TestSnapshotStore_ConcurrentReadWrite(t *testing.T) {
+	t.Parallel()
+
+	store := memory.NewSnapshotStore()
+	aggregateID := typeid.NewV4("mockentity")
+
+	const iterations = 200
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		for i := 1; i <= iterations; i++ {
+			_ = store.WriteSnapshot(t.Context(), &snapshotstore.AggregateSnapshot{
+				AggregateID:      aggregateID,
+				AggregateVersion: int64(i),
+				Data:             []byte(`{}`),
+			})
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			_, _ = store.ReadSnapshot(t.Context(), aggregateID, snapshotstore.ReadSnapshotOptions{})
+		}
+	}()
+
+	wg.Wait()
+}
+
+func TestSnapshotStore_ReadSnapshot(t *testing.T) {
+	t.Parallel()
+
+	t.Run("reports not found for an aggregate with no snapshots", func(t *testing.T) {
+		t.Parallel()
+
+		store := memory.NewSnapshotStore()
+
+		_, err := store.ReadSnapshot(t.Context(), typeid.NewV4("mockentity"), snapshotstore.ReadSnapshotOptions{})
+		if !errors.Is(err, snapshotstore.ErrSnapshotNotFound) {
+			t.Errorf("want ErrSnapshotNotFound, got %v", err)
+		}
+	})
+
+	t.Run("returns the latest snapshot by default", func(t *testing.T) {
+		t.Parallel()
+
+		store := memory.NewSnapshotStore()
+		aggregateID := typeid.NewV4("mockentity")
+		writeVersions(t, store, aggregateID, 1, 2, 3)
+
+		snap, err := store.ReadSnapshot(t.Context(), aggregateID, snapshotstore.ReadSnapshotOptions{})
+		if err != nil {
+			t.Fatalf("reading snapshot: %v", err)
+		}
+
+		if want := int64(3); snap.AggregateVersion != want {
+			t.Errorf("want version %d, got %d", want, snap.AggregateVersion)
+		}
+	})
+
+	t.Run("rejects a snapshot older than the most recent", func(t *testing.T) {
+		t.Parallel()
+
+		store := memory.NewSnapshotStore()
+		aggregateID := typeid.NewV4("mockentity")
+		writeVersions(t, store, aggregateID, 5)
+
+		err := store.WriteSnapshot(t.Context(), &snapshotstore.AggregateSnapshot{
+			AggregateID:      aggregateID,
+			AggregateVersion: 4,
+			Data:             []byte(`{}`),
+		})
+		if err == nil {
+			t.Error("want an error writing a snapshot older than the most recent, got nil")
+		}
+	})
+
+	// The default retention policy keeps only the most recent snapshot, so a MaxVersion
+	// below it has nothing to return. This pins the retention loop's behavior.
+	t.Run("reports not found when MaxVersion predates every retained snapshot", func(t *testing.T) {
+		t.Parallel()
+
+		store := memory.NewSnapshotStore()
+		aggregateID := typeid.NewV4("mockentity")
+		writeVersions(t, store, aggregateID, 1, 2, 3)
+
+		_, err := store.ReadSnapshot(t.Context(), aggregateID, snapshotstore.ReadSnapshotOptions{MaxVersion: 2})
+		if !errors.Is(err, snapshotstore.ErrSnapshotNotFound) {
+			t.Errorf("want ErrSnapshotNotFound, got %v", err)
+		}
+	})
+
+	t.Run("honors a MaxVersion at or above the retained snapshot", func(t *testing.T) {
+		t.Parallel()
+
+		store := memory.NewSnapshotStore()
+		aggregateID := typeid.NewV4("mockentity")
+		writeVersions(t, store, aggregateID, 1, 2, 3)
+
+		snap, err := store.ReadSnapshot(t.Context(), aggregateID, snapshotstore.ReadSnapshotOptions{MaxVersion: 3})
+		if err != nil {
+			t.Fatalf("reading snapshot: %v", err)
+		}
+
+		if want := int64(3); snap.AggregateVersion != want {
+			t.Errorf("want version %d, got %d", want, snap.AggregateVersion)
+		}
+	})
+}
+
+func writeVersions(t *testing.T, store *memory.SnapshotStore, aggregateID typeid.ID, versions ...int64) {
+	t.Helper()
+
+	for _, version := range versions {
+		if err := store.WriteSnapshot(context.Background(), &snapshotstore.AggregateSnapshot{
+			AggregateID:      aggregateID,
+			AggregateVersion: version,
+			Data:             []byte(`{}`),
+		}); err != nil {
+			t.Fatalf("writing snapshot at version %d: %v", version, err)
+		}
+	}
+}

--- a/typeid/typeid.go
+++ b/typeid/typeid.go
@@ -17,17 +17,6 @@ func (id ID) String() string {
 	return id.Type + "_" + id.UUID.String()
 }
 
-// ShortString returns a shortened string representation of the ID in the format "type_xxxxxxxx",
-// where "xxxxxxxx" is the first 8 characters of the UUID.
-//
-// Example: "user_9791012c"
-//
-// ShortString is provided for convenience in logging and debugging, but is not utilized by
-// any core Estoria components.
-func (id ID) ShortString() string {
-	return id.Type + "_" + id.UUID.String()[0:8]
-}
-
 // NewV4 creates a new ID with the given type name and a new v4 UUID.
 //
 // UUID v4 is a randomly generated UUID.


### PR DESCRIPTION
## Summary

Seven correctness bugs across the aggregate and snapshot stores. Each fix carries a regression test verified to fail against the previous behavior.

## Fixes

**`SnapshottingStore.Save` mutated the caller's `SaveOptions`.** It set `SkipApply` on the pointer it was handed, so a reused options struct silently skipped applying events on the next save through any store, leaving the aggregate's in-memory version stale — which surfaced one save later as a spurious `StreamVersionMismatchError`. It now copies.

**A failed snapshot unmarshal corrupted the entity.** Decoding targeted the aggregate's live entity, and with a pointer entity type the marshaler writes through it in place. A snapshot that parses cleanly but disagrees on a field's type — ordinary schema drift — applied the fields it could before failing; the store then logged a warning, replayed events onto the polluted entity, and returned a `nil` error. Decoding now targets a fresh entity and commits only on success. Truncated JSON does not reproduce this, since `encoding/json` validates the whole document before writing; the payload has to parse and fail on a type mismatch.

**`CachedStore.Load` ignored `LoadOptions.ToVersion`.** A cache hit returned before the options were consulted, so a load asking for version 3 returned whatever version was last cached. Versioned loads now bypass the cache in both directions — writing a deliberately-truncated aggregate back would serve that stale version to later full loads.

**`snapshotstore/memory` had no mutex** while its `eventstore/memory` sibling did, so any concurrent reader and writer raced.

**The eventstream snapshot store ignored `ReadSnapshotOptions.MaxVersion`,** which made every versioned load through a `SnapshottingStore` fail outright: the newest snapshot was applied past the target, and the inner store then rejected the aggregate as more recent than requested. Same file — an absent snapshot stream returned a wrapped `ErrStreamNotFound` rather than `ErrSnapshotNotFound`, so `SnapshottingStore.Hydrate`'s check missed and every first load of a never-snapshotted aggregate logged a warning; and the iterator was never closed, leaking a cursor per read against a real backend.

**Nil handling was inconsistent.** `CachedStore.Save` and `HookableStore.Hydrate`/`Save` panicked where `EventSourcedStore` returns `ErrNilAggregate`, and `NewCachedStore` accepted a nil cache, deferring the failure to a nil dereference on the first `Load`.

## API change

`AggregateCache.GetAggregate` now takes `typeid.ID` instead of `uuid.UUID`. All four `estoria-contrib` caches already had this signature and have been unusable since contrib bumped to v0.3.0 — nothing asserted the interface, so each package compiled on its own and CI stayed green. Type-qualified keys also keep a cache backend shared across aggregate types from producing colliding, opaque keys.

Breaking for anyone implementing `AggregateCache` directly.

## Removed

`typeid.ShortString`, unused and documented as such in its own comment. `snapshotstore/memory.JSONSnapshotMarshaler`, a duplicate of the one in `snapshotstore`, along with the `marshaler` field it was assigned to but never called through. `mockStreamIterator.All`, left from a removed API.

## Tests

Every fix has a regression test, each verified non-vacuous by reverting the fix and confirming failure — including the versioned-load case, which fails with the original `aggregate is at more recent version (10) than requested version (1)`.

`snapshotstore/memory` goes from 0% to 100% coverage and `snapshotstore/eventstream` from 0% to 82.9%. Neither package had a test file before, which is where three of these bugs lived.

One note for future test work: every existing entity double is value-typed, so the pointer-entity path that produced the snapshot corruption was never exercised. This adds a `mockPointerEntity` to cover it.
