### PR TITLE
Add event and snapshot store acceptance suites

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -113,6 +113,15 @@ linters:
           - prealloc
           - testpackage
         path: _test\.go
+      # The storetest packages are test code that has to live in non-test files so
+      # third-party backends can import the suites. thelper reads their clause
+      # functions as helpers because each takes a *testing.T, but they are subtest
+      # bodies: marking them t.Helper() would report every failure at the suite
+      # runner's line instead of the assertion that failed, which is the one thing
+      # a backend needs to see.
+      - linters:
+          - thelper
+        path: storetest/
     paths:
       - third_party$
       - builtin$

--- a/eventstore/event_store.go
+++ b/eventstore/event_store.go
@@ -25,9 +25,10 @@ type StreamReader interface {
 	// forward read with an AfterVersion at or beyond the stream's latest version) should
 	// yield an iterator that immediately reports ErrEndOfEventStream.
 	//
-	// Consumers should tolerate both. Distinguishing the two cases can cost an
-	// implementation an additional existence check, and some do not make it, so a
-	// filtered read reporting ErrStreamNotFound may mean either.
+	// The distinction is required rather than advisory, and eventstore/storetest enforces
+	// it. Making it can cost an implementation an extra existence check; not making it
+	// leaves any aggregate snapshotted at its own stream tip unloadable, because the read
+	// for events after the snapshot reports the whole stream missing.
 	ReadStream(ctx context.Context, id typeid.ID, opts ReadStreamOptions) (StreamIterator, error)
 }
 
@@ -216,31 +217,6 @@ func (e InitializationError) Unwrap() error {
 // Is returns true if the target is an InitializationError.
 func (e InitializationError) Is(target error) bool {
 	_, ok := target.(InitializationError)
-	return ok
-}
-
-// EventExistsError is returned when an event with the same ID already exists.
-type EventExistsError struct {
-	EventID typeid.ID
-
-	// Err is the underlying error from the storage backend (e.g., a database constraint
-	// violation). It may be nil if the duplicate was detected at the application level.
-	Err error
-}
-
-// Error returns the error message.
-func (e EventExistsError) Error() string {
-	return fmt.Sprintf("event already exists: %s", e.EventID)
-}
-
-// Unwrap returns the underlying error.
-func (e EventExistsError) Unwrap() error {
-	return e.Err
-}
-
-// Is returns true if the target is an EventExistsError.
-func (e EventExistsError) Is(target error) bool {
-	_, ok := target.(EventExistsError)
 	return ok
 }
 

--- a/eventstore/memory/event_store_acceptance_test.go
+++ b/eventstore/memory/event_store_acceptance_test.go
@@ -1,0 +1,24 @@
+package memory_test
+
+import (
+	"testing"
+
+	"github.com/go-estoria/estoria/eventstore"
+	"github.com/go-estoria/estoria/eventstore/memory"
+	"github.com/go-estoria/estoria/eventstore/storetest"
+)
+
+// The in-memory store is the reference implementation: it defines what the acceptance
+// suite's clauses mean. A clause it cannot satisfy is a wrong clause, not a wrong store.
+func TestEventStore_AcceptanceTest(t *testing.T) {
+	t.Parallel()
+
+	store, err := memory.NewEventStore()
+	if err != nil {
+		t.Fatalf("creating event store: %v", err)
+	}
+
+	storetest.RunEventStoreSuite(t, func(*testing.T) eventstore.Store {
+		return store
+	})
+}

--- a/eventstore/storetest/storetest.go
+++ b/eventstore/storetest/storetest.go
@@ -1,0 +1,435 @@
+// Package storetest provides an acceptance suite that every eventstore.Store
+// implementation is expected to pass.
+//
+// The suite is the executable form of the contract documented on the eventstore
+// interfaces. It lives beside those interfaces so that core's own reference
+// implementation and every third-party backend are held to one definition of correct
+// behavior, and so that adding a clause here surfaces every implementation that violates
+// it.
+//
+// A backend wires it up with a single test:
+//
+//	func TestEventStore_AcceptanceTest(t *testing.T) {
+//		storetest.RunEventStoreSuite(t, func(t *testing.T) eventstore.Store {
+//			return newStoreForTest(t)
+//		})
+//	}
+package storetest
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"reflect"
+	"testing"
+
+	"github.com/go-estoria/estoria/eventstore"
+	"github.com/go-estoria/estoria/typeid"
+)
+
+// NewStoreFunc returns an event store for one clause of the acceptance suite to use.
+//
+// Implementations may return the same store on every call. Every clause writes to a
+// freshly generated stream ID and asserts only on that stream, so sharing one store across
+// clauses is safe and avoids standing up a backend per clause.
+type NewStoreFunc func(t *testing.T) eventstore.Store
+
+// RunEventStoreSuite runs the event store acceptance suite against stores returned by
+// newStore, reporting each clause as its own named subtest so a failing backend learns
+// which part of the contract it violates.
+//
+// The suite does not call t.Parallel: callers typically parallelize at the outer level, and
+// parallel clauses sharing one store would race. It does not skip on -short either; whether
+// a backend is reachable is the caller's concern.
+func RunEventStoreSuite(t *testing.T, newStore NewStoreFunc) {
+	t.Helper()
+
+	for _, clause := range []struct {
+		name string
+		run  func(t *testing.T, store eventstore.Store)
+	}{
+		{"assigns an ID, stream ID, stream version, and timestamp to each appended event", clauseAssignsEventFields},
+		{"round-trips event data", clauseRoundTripsData},
+		{"round-trips event metadata", clauseRoundTripsMetadata},
+		{"does not modify the events it is given", clauseDoesNotMutateEvents},
+		{"reports ErrStreamNotFound for a stream that was never written", clauseUnwrittenStreamNotFound},
+		{"yields an empty iterator when reading past the stream tip", clauseReadPastTip},
+		{"reads a stream in reverse", clauseReadsReverse},
+		{"limits a read to Count events", clauseHonorsCount},
+		{"appends when ExpectVersion matches the current version", clauseExpectVersionMatch},
+		{"rejects an append when ExpectVersion does not match", clauseExpectVersionMismatch},
+		{"appends to a new stream when StreamMustNotExist is set", clauseStreamMustNotExistNew},
+		{"rejects an append to an existing stream when StreamMustNotExist is set", clauseStreamMustNotExistExisting},
+		{"rejects an append setting both ExpectVersion and StreamMustNotExist", clauseMutuallyExclusiveOptions},
+	} {
+		t.Run(clause.name, func(t *testing.T) {
+			clause.run(t, newStore(t))
+		})
+	}
+}
+
+// clauseAssignsEventFields pins the fields an event store is responsible for populating.
+// A caller supplies only Type, Data, and Metadata; everything else on a read event is the
+// store's to assign, and callers rely on all four.
+func clauseAssignsEventFields(t *testing.T, store eventstore.Store) {
+	streamID := newStreamID()
+	appendEvents(t, store, streamID, 3, eventstore.AppendStreamOptions{})
+
+	events := readStream(t, store, streamID, eventstore.ReadStreamOptions{})
+	if len(events) != 3 {
+		t.Fatalf("want 3 events, got %d", len(events))
+	}
+
+	for i, event := range events {
+		if event.ID.UUID.IsNil() {
+			t.Errorf("event %d: want a non-nil assigned event ID, got the zero UUID", i)
+		}
+
+		if event.StreamID != streamID {
+			t.Errorf("event %d: want stream ID %s, got %s", i, streamID, event.StreamID)
+		}
+
+		// Stream versions are 1-based and gapless: the first event in a stream is version 1.
+		if want := int64(i + 1); event.StreamVersion != want {
+			t.Errorf("event %d: want stream version %d, got %d", i, want, event.StreamVersion)
+		}
+
+		if event.Timestamp.IsZero() {
+			t.Errorf("event %d: want an assigned timestamp, got the zero time", i)
+		}
+	}
+}
+
+// clauseRoundTripsData is the base guarantee: bytes in, same bytes out, in append order.
+func clauseRoundTripsData(t *testing.T, store eventstore.Store) {
+	const count = 10
+
+	streamID := newStreamID()
+	appendEvents(t, store, streamID, count, eventstore.AppendStreamOptions{})
+
+	read := readStream(t, store, streamID, eventstore.ReadStreamOptions{})
+	if len(read) != count {
+		t.Fatalf("want %d events, got %d", count, len(read))
+	}
+
+	for i := range read {
+		// Assert against independently rebuilt payloads rather than the slice handed to
+		// AppendStream: a store that writes through the caller's events would otherwise
+		// mutate the expectation into agreeing with itself.
+		//
+		// Compare semantically, since backends that store JSON natively (Postgres jsonb,
+		// Mongo BSON) may reorder keys or renormalize whitespace. That is not a break.
+		assertJSONEqual(t, i, eventData(i), read[i].Data)
+	}
+}
+
+// clauseDoesNotMutateEvents pins that AppendStream treats its events as read-only. Callers
+// reuse the slice — retrying an append after a version conflict is the obvious case — and a
+// store that rewrites entries in place corrupts the retry.
+func clauseDoesNotMutateEvents(t *testing.T, store eventstore.Store) {
+	const count = 3
+
+	streamID := newStreamID()
+	events := appendEvents(t, store, streamID, count, eventstore.AppendStreamOptions{})
+
+	for i, event := range events {
+		if event.Type != eventType {
+			t.Errorf("event %d: store modified Type: want %q, got %q", i, eventType, event.Type)
+		}
+
+		if !reflect.DeepEqual(event.Data, eventData(i)) {
+			t.Errorf("event %d: store modified Data: want %s, got %s", i, eventData(i), event.Data)
+		}
+	}
+}
+
+// clauseRoundTripsMetadata covers the field that carries correlation, causation, and tracing
+// data. It is separate from the data round-trip because a backend can persist the payload
+// faithfully and still drop metadata entirely, which is invisible until something depends
+// on it.
+func clauseRoundTripsMetadata(t *testing.T, store eventstore.Store) {
+	streamID := newStreamID()
+	want := map[string]string{"correlation_id": "abc-123", "actor": "user-7"}
+
+	err := store.AppendStream(t.Context(), streamID, []*eventstore.WritableEvent{{
+		Type: eventType,
+		Data: eventData(0),
+		// Clone, so a store that writes through the caller's map cannot edit the
+		// expectation into agreeing with what it stored.
+		Metadata: maps.Clone(want),
+	}}, eventstore.AppendStreamOptions{})
+	if err != nil {
+		t.Fatalf("appending event: %v", err)
+	}
+
+	events := readStream(t, store, streamID, eventstore.ReadStreamOptions{})
+	if len(events) != 1 {
+		t.Fatalf("want 1 event, got %d", len(events))
+	}
+
+	if got := events[0].Metadata; !reflect.DeepEqual(got, want) {
+		t.Errorf("want metadata %v, got %v", want, got)
+	}
+}
+
+// clauseUnwrittenStreamNotFound pins the "absent" half of the ReadStream contract: a stream
+// that was never written reports ErrStreamNotFound.
+func clauseUnwrittenStreamNotFound(t *testing.T, store eventstore.Store) {
+	iter, err := store.ReadStream(t.Context(), newStreamID(), eventstore.ReadStreamOptions{})
+	if err == nil {
+		defer iter.Close(t.Context())
+	}
+
+	if !errors.Is(err, eventstore.ErrStreamNotFound) {
+		t.Errorf("want ErrStreamNotFound reading a stream that was never written, got %v", err)
+	}
+}
+
+// clauseReadPastTip pins the other half: a stream that exists but has nothing matching the
+// read options is not the same as an absent stream. Backends that infer absence from an
+// empty filtered read make any aggregate snapshotted at its own tip unloadable.
+func clauseReadPastTip(t *testing.T, store eventstore.Store) {
+	streamID := newStreamID()
+	appendEvents(t, store, streamID, 10, eventstore.AppendStreamOptions{})
+
+	iter, err := store.ReadStream(t.Context(), streamID, eventstore.ReadStreamOptions{AfterVersion: 10})
+	if err != nil {
+		t.Fatalf("want a readable iterator past the stream tip, got error: %v", err)
+	}
+
+	defer iter.Close(t.Context())
+
+	if _, err := iter.Next(t.Context()); !errors.Is(err, eventstore.ErrEndOfEventStream) {
+		t.Errorf("want ErrEndOfEventStream reading past the stream tip, got %v", err)
+	}
+}
+
+// clauseReadsReverse pins reverse reads, including AfterVersion's inclusive upper-bound
+// meaning in that direction, which differs from its exclusive lower-bound meaning going
+// forward.
+func clauseReadsReverse(t *testing.T, store eventstore.Store) {
+	streamID := newStreamID()
+	appendEvents(t, store, streamID, 5, eventstore.AppendStreamOptions{})
+
+	t.Run("from the end of the stream by default", func(t *testing.T) {
+		events := readStream(t, store, streamID, eventstore.ReadStreamOptions{
+			Direction: eventstore.Reverse,
+		})
+
+		assertVersions(t, events, 5, 4, 3, 2, 1)
+	})
+
+	t.Run("from an inclusive AfterVersion", func(t *testing.T) {
+		events := readStream(t, store, streamID, eventstore.ReadStreamOptions{
+			Direction:    eventstore.Reverse,
+			AfterVersion: 3,
+		})
+
+		assertVersions(t, events, 3, 2, 1)
+	})
+}
+
+// clauseHonorsCount pins the read limit in both directions. SnapshottingStore reads a
+// single event off the tip of a snapshot stream, so a backend that ignores Count reads an
+// entire stream to answer that.
+func clauseHonorsCount(t *testing.T, store eventstore.Store) {
+	streamID := newStreamID()
+	appendEvents(t, store, streamID, 5, eventstore.AppendStreamOptions{})
+
+	t.Run("reading forward", func(t *testing.T) {
+		events := readStream(t, store, streamID, eventstore.ReadStreamOptions{Count: 2})
+		assertVersions(t, events, 1, 2)
+	})
+
+	t.Run("reading in reverse", func(t *testing.T) {
+		events := readStream(t, store, streamID, eventstore.ReadStreamOptions{
+			Direction: eventstore.Reverse,
+			Count:     2,
+		})
+
+		assertVersions(t, events, 5, 4)
+	})
+}
+
+// clauseExpectVersionMatch covers the success half of optimistic concurrency: an append
+// whose expectation holds must go through.
+func clauseExpectVersionMatch(t *testing.T, store eventstore.Store) {
+	streamID := newStreamID()
+	appendEvents(t, store, streamID, 3, eventstore.AppendStreamOptions{})
+
+	appendEvents(t, store, streamID, 1, eventstore.AppendStreamOptions{
+		ExpectVersion: eventstore.VersionPtr(3),
+	})
+
+	events := readStream(t, store, streamID, eventstore.ReadStreamOptions{})
+	if len(events) != 4 {
+		t.Fatalf("want 4 events after an append with a matching ExpectVersion, got %d", len(events))
+	}
+}
+
+// clauseExpectVersionMismatch covers the half that makes optimistic concurrency worth
+// anything: a stale expectation must be refused, with a typed error carrying both versions
+// so a caller can retry.
+func clauseExpectVersionMismatch(t *testing.T, store eventstore.Store) {
+	streamID := newStreamID()
+	appendEvents(t, store, streamID, 3, eventstore.AppendStreamOptions{})
+
+	err := store.AppendStream(t.Context(), streamID, writableEvents(1), eventstore.AppendStreamOptions{
+		ExpectVersion: eventstore.VersionPtr(2),
+	})
+	if !errors.Is(err, eventstore.StreamVersionMismatchError{}) {
+		t.Fatalf("want StreamVersionMismatchError appending with a stale ExpectVersion, got %v", err)
+	}
+
+	// Not folded into the errors.Is above: a backend returning a *pointer* to the error
+	// satisfies Is (the method has a value receiver) but not As, and skipping the version
+	// assertions on that path would make this clause quietly stop checking anything.
+	var mismatch eventstore.StreamVersionMismatchError
+	if !errors.As(err, &mismatch) {
+		t.Fatalf("want an error unwrapping to StreamVersionMismatchError, got %T: %v", err, err)
+	}
+
+	if mismatch.ExpectedVersion != 2 {
+		t.Errorf("want ExpectedVersion 2, got %d", mismatch.ExpectedVersion)
+	}
+
+	if mismatch.ActualVersion != 3 {
+		t.Errorf("want ActualVersion 3, got %d", mismatch.ActualVersion)
+	}
+
+	// A refused append must not be a partial one.
+	if events := readStream(t, store, streamID, eventstore.ReadStreamOptions{}); len(events) != 3 {
+		t.Errorf("want the stream unchanged at 3 events after a refused append, got %d", len(events))
+	}
+}
+
+// clauseStreamMustNotExistNew covers create-if-absent, the expectation a caller has no
+// version number for.
+func clauseStreamMustNotExistNew(t *testing.T, store eventstore.Store) {
+	streamID := newStreamID()
+	appendEvents(t, store, streamID, 2, eventstore.AppendStreamOptions{StreamMustNotExist: true})
+
+	if events := readStream(t, store, streamID, eventstore.ReadStreamOptions{}); len(events) != 2 {
+		t.Errorf("want 2 events, got %d", len(events))
+	}
+}
+
+func clauseStreamMustNotExistExisting(t *testing.T, store eventstore.Store) {
+	streamID := newStreamID()
+	appendEvents(t, store, streamID, 2, eventstore.AppendStreamOptions{})
+
+	err := store.AppendStream(t.Context(), streamID, writableEvents(1), eventstore.AppendStreamOptions{
+		StreamMustNotExist: true,
+	})
+	if !errors.Is(err, eventstore.StreamVersionMismatchError{}) {
+		t.Fatalf("want StreamVersionMismatchError appending to an existing stream with StreamMustNotExist, got %v", err)
+	}
+
+	if events := readStream(t, store, streamID, eventstore.ReadStreamOptions{}); len(events) != 2 {
+		t.Errorf("want the stream unchanged at 2 events after a refused append, got %d", len(events))
+	}
+}
+
+// clauseMutuallyExclusiveOptions pins that the two expectations are refused together rather
+// than one silently winning. The contract does not name an error type here, so this asserts
+// only that the append fails.
+func clauseMutuallyExclusiveOptions(t *testing.T, store eventstore.Store) {
+	streamID := newStreamID()
+
+	err := store.AppendStream(t.Context(), streamID, writableEvents(1), eventstore.AppendStreamOptions{
+		ExpectVersion:      eventstore.VersionPtr(0),
+		StreamMustNotExist: true,
+	})
+	if err == nil {
+		t.Fatal("want an error appending with both ExpectVersion and StreamMustNotExist, got nil")
+	}
+}
+
+// newStreamID returns a stream ID unique to one clause, so clauses sharing a store cannot
+// observe each other's writes.
+func newStreamID() typeid.ID {
+	return typeid.NewV4("storetest")
+}
+
+const eventType = "eventtype"
+
+// eventData is the payload the suite writes at 0-based position i. Clauses rebuild expected
+// payloads through this rather than reading them back off the slice they handed the store.
+func eventData(i int) []byte {
+	return fmt.Appendf(nil, `{"index":%d}`, i+1)
+}
+
+// writableEvents builds n events whose data carries a 1-based index, so a read can be
+// checked for both content and order.
+func writableEvents(n int) []*eventstore.WritableEvent {
+	events := make([]*eventstore.WritableEvent, 0, n)
+	for i := range n {
+		events = append(events, &eventstore.WritableEvent{
+			Type: eventType,
+			Data: eventData(i),
+		})
+	}
+
+	return events
+}
+
+func appendEvents(t *testing.T, store eventstore.Store, streamID typeid.ID, n int, opts eventstore.AppendStreamOptions) []*eventstore.WritableEvent {
+	t.Helper()
+
+	events := writableEvents(n)
+	if err := store.AppendStream(t.Context(), streamID, events, opts); err != nil {
+		t.Fatalf("appending %d events: %v", n, err)
+	}
+
+	return events
+}
+
+func readStream(t *testing.T, store eventstore.Store, streamID typeid.ID, opts eventstore.ReadStreamOptions) []*eventstore.Event {
+	t.Helper()
+
+	iter, err := store.ReadStream(t.Context(), streamID, opts)
+	if err != nil {
+		t.Fatalf("reading stream: %v", err)
+	}
+
+	t.Cleanup(func() { _ = iter.Close(context.WithoutCancel(t.Context())) })
+
+	events, err := eventstore.ReadAll(t.Context(), iter)
+	if err != nil {
+		t.Fatalf("reading events: %v", err)
+	}
+
+	return events
+}
+
+func assertVersions(t *testing.T, events []*eventstore.Event, want ...int64) {
+	t.Helper()
+
+	got := make([]int64, 0, len(events))
+	for _, event := range events {
+		got = append(got, event.StreamVersion)
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("want stream versions %v, got %v", want, got)
+	}
+}
+
+func assertJSONEqual(t *testing.T, index int, want, got []byte) {
+	t.Helper()
+
+	var wantValue, gotValue any
+	if err := json.Unmarshal(want, &wantValue); err != nil {
+		t.Fatalf("event %d: unmarshaling appended data: %v", index, err)
+	}
+
+	if err := json.Unmarshal(got, &gotValue); err != nil {
+		t.Fatalf("event %d: unmarshaling read data %q: %v", index, got, err)
+	}
+
+	if !reflect.DeepEqual(wantValue, gotValue) {
+		t.Errorf("event %d: want data %s, got %s", index, want, got)
+	}
+}

--- a/snapshotstore/eventstream/event_stream_store_acceptance_test.go
+++ b/snapshotstore/eventstream/event_stream_store_acceptance_test.go
@@ -1,0 +1,31 @@
+package snapshotstore_test
+
+import (
+	"testing"
+
+	"github.com/go-estoria/estoria/eventstore/memory"
+	"github.com/go-estoria/estoria/snapshotstore"
+	eventstreamstore "github.com/go-estoria/estoria/snapshotstore/eventstream"
+	"github.com/go-estoria/estoria/snapshotstore/storetest"
+)
+
+// Unlike the in-memory snapshot store, this one retains every snapshot ever written, so it
+// exercises the MaxVersion clause's non-trivial branch: it must return the newest snapshot
+// at or below the bound rather than reporting one absent.
+func TestEventStreamStore_AcceptanceTest(t *testing.T) {
+	t.Parallel()
+
+	storetest.RunSnapshotStoreSuite(t, func(t *testing.T) snapshotstore.SnapshotStore {
+		t.Helper()
+
+		// A fresh backing event store per clause: snapshot streams are derived from the
+		// aggregate ID, so clauses cannot collide, but a shared store would also share the
+		// global position counter for no benefit.
+		eventStore, err := memory.NewEventStore()
+		if err != nil {
+			t.Fatalf("creating backing event store: %v", err)
+		}
+
+		return eventstreamstore.NewEventStreamStore(eventStore)
+	})
+}

--- a/snapshotstore/memory/snapshot_store_acceptance_test.go
+++ b/snapshotstore/memory/snapshot_store_acceptance_test.go
@@ -1,0 +1,21 @@
+package memory_test
+
+import (
+	"testing"
+
+	"github.com/go-estoria/estoria/snapshotstore"
+	"github.com/go-estoria/estoria/snapshotstore/memory"
+	"github.com/go-estoria/estoria/snapshotstore/storetest"
+)
+
+// The in-memory store retains only its newest snapshot, which is why the suite's MaxVersion
+// clause accepts ErrSnapshotNotFound as an answer.
+func TestSnapshotStore_AcceptanceTest(t *testing.T) {
+	t.Parallel()
+
+	store := memory.NewSnapshotStore()
+
+	storetest.RunSnapshotStoreSuite(t, func(*testing.T) snapshotstore.SnapshotStore {
+		return store
+	})
+}

--- a/snapshotstore/storetest/storetest.go
+++ b/snapshotstore/storetest/storetest.go
@@ -1,0 +1,230 @@
+// Package storetest provides an acceptance suite that every snapshotstore.SnapshotStore
+// implementation is expected to pass.
+//
+// A backend wires it up with a single test:
+//
+//	func TestSnapshotStore_AcceptanceTest(t *testing.T) {
+//		storetest.RunSnapshotStoreSuite(t, func(t *testing.T) snapshotstore.SnapshotStore {
+//			return newStoreForTest(t)
+//		})
+//	}
+package storetest
+
+import (
+	"errors"
+	"reflect"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/go-estoria/estoria/snapshotstore"
+	"github.com/go-estoria/estoria/typeid"
+)
+
+// NewStoreFunc returns a snapshot store for one clause of the acceptance suite to use.
+//
+// Implementations may return the same store on every call. Every clause uses a freshly
+// generated aggregate ID and asserts only on that aggregate.
+type NewStoreFunc func(t *testing.T) snapshotstore.SnapshotStore
+
+// RunSnapshotStoreSuite runs the snapshot store acceptance suite against stores returned by
+// newStore, reporting each clause as its own named subtest.
+//
+// The suite deliberately says nothing about retention. How many snapshots a store keeps is
+// a store's own policy, so the clauses below are written to hold for a store that retains
+// only the newest snapshot and for one that retains every snapshot ever written.
+//
+// The suite does not call t.Parallel; parallelism is the caller's to choose.
+func RunSnapshotStoreSuite(t *testing.T, newStore NewStoreFunc) {
+	t.Helper()
+
+	for _, clause := range []struct {
+		name string
+		run  func(t *testing.T, store snapshotstore.SnapshotStore)
+	}{
+		{"reports ErrSnapshotNotFound for an aggregate that was never snapshotted", clauseNeverSnapshotted},
+		{"round-trips a snapshot", clauseRoundTripsSnapshot},
+		{"does not modify the snapshot it is given", clauseDoesNotMutateSnapshot},
+		{"returns the most recently written snapshot by default", clauseReturnsMostRecent},
+		{"never returns a snapshot newer than MaxVersion", clauseHonorsMaxVersion},
+		{"keeps snapshots for different aggregates separate", clauseSeparatesAggregates},
+	} {
+		t.Run(clause.name, func(t *testing.T) {
+			clause.run(t, newStore(t))
+		})
+	}
+}
+
+// clauseNeverSnapshotted pins the sentinel that SnapshottingStore checks before falling
+// back to full hydration. A store reporting anything else for a first-ever load turns an
+// ordinary cold start into a load failure.
+func clauseNeverSnapshotted(t *testing.T, store snapshotstore.SnapshotStore) {
+	_, err := store.ReadSnapshot(t.Context(), newAggregateID(), snapshotstore.ReadSnapshotOptions{})
+	if !errors.Is(err, snapshotstore.ErrSnapshotNotFound) {
+		t.Errorf("want ErrSnapshotNotFound for an aggregate with no snapshots, got %v", err)
+	}
+}
+
+// clauseRoundTripsSnapshot pins every field a store is responsible for preserving. The
+// payload matters most: it is an opaque entity encoding, and a store that mangles it
+// produces an aggregate hydrated to a corrupt state rather than an outright error.
+func clauseRoundTripsSnapshot(t *testing.T, store snapshotstore.SnapshotStore) {
+	aggregateID := newAggregateID()
+
+	const wantVersion = int64(7)
+
+	wantTimestamp := time.Date(2026, time.August, 5, 12, 0, 0, 0, time.UTC)
+	wantData := []byte(`{"owner":"alice","balance":42}`)
+
+	// Hand the store its own copy and assert against the locals above, never against the
+	// struct the store was given. A store that writes through the caller's snapshot would
+	// otherwise mutate the expectation into agreeing with whatever it stored.
+	if err := store.WriteSnapshot(t.Context(), &snapshotstore.AggregateSnapshot{
+		AggregateID:      aggregateID,
+		AggregateVersion: wantVersion,
+		Timestamp:        wantTimestamp,
+		Data:             slices.Clone(wantData),
+	}); err != nil {
+		t.Fatalf("writing snapshot: %v", err)
+	}
+
+	got, err := store.ReadSnapshot(t.Context(), aggregateID, snapshotstore.ReadSnapshotOptions{})
+	if err != nil {
+		t.Fatalf("reading snapshot: %v", err)
+	}
+
+	if got.AggregateID != aggregateID {
+		t.Errorf("want aggregate ID %s, got %s", aggregateID, got.AggregateID)
+	}
+
+	if got.AggregateVersion != wantVersion {
+		t.Errorf("want aggregate version %d, got %d", wantVersion, got.AggregateVersion)
+	}
+
+	if !got.Timestamp.Equal(wantTimestamp) {
+		t.Errorf("want timestamp %s, got %s", wantTimestamp, got.Timestamp)
+	}
+
+	if !reflect.DeepEqual(got.Data, wantData) {
+		t.Errorf("want data %s, got %s", wantData, got.Data)
+	}
+}
+
+// clauseDoesNotMutateSnapshot pins that WriteSnapshot treats its argument as read-only.
+// Callers reuse and inspect the struct after writing, and a store that scribbles on it
+// corrupts state the caller still owns — the failure mode is silent, because the caller's
+// own later reads agree with the damage.
+func clauseDoesNotMutateSnapshot(t *testing.T, store snapshotstore.SnapshotStore) {
+	aggregateID := newAggregateID()
+
+	const wantVersion = int64(4)
+
+	wantTimestamp := time.Date(2026, time.August, 5, 12, 0, 0, 0, time.UTC)
+	wantData := []byte(`{"owner":"bob","balance":7}`)
+
+	snap := &snapshotstore.AggregateSnapshot{
+		AggregateID:      aggregateID,
+		AggregateVersion: wantVersion,
+		Timestamp:        wantTimestamp,
+		Data:             slices.Clone(wantData),
+	}
+
+	if err := store.WriteSnapshot(t.Context(), snap); err != nil {
+		t.Fatalf("writing snapshot: %v", err)
+	}
+
+	if snap.AggregateID != aggregateID {
+		t.Errorf("store modified AggregateID: want %s, got %s", aggregateID, snap.AggregateID)
+	}
+
+	if snap.AggregateVersion != wantVersion {
+		t.Errorf("store modified AggregateVersion: want %d, got %d", wantVersion, snap.AggregateVersion)
+	}
+
+	if !snap.Timestamp.Equal(wantTimestamp) {
+		t.Errorf("store modified Timestamp: want %s, got %s", wantTimestamp, snap.Timestamp)
+	}
+
+	if !reflect.DeepEqual(snap.Data, wantData) {
+		t.Errorf("store modified Data: want %s, got %s", wantData, snap.Data)
+	}
+}
+
+// clauseReturnsMostRecent pins that an unbounded read finds the newest snapshot. Returning
+// an older one is not a correctness failure on its own — hydration replays the remaining
+// events either way — but it silently forfeits the point of snapshotting.
+func clauseReturnsMostRecent(t *testing.T, store snapshotstore.SnapshotStore) {
+	aggregateID := newAggregateID()
+	writeVersions(t, store, aggregateID, 1, 2, 3)
+
+	snap, err := store.ReadSnapshot(t.Context(), aggregateID, snapshotstore.ReadSnapshotOptions{})
+	if err != nil {
+		t.Fatalf("reading snapshot: %v", err)
+	}
+
+	if want := int64(3); snap.AggregateVersion != want {
+		t.Errorf("want aggregate version %d, got %d", want, snap.AggregateVersion)
+	}
+}
+
+// clauseHonorsMaxVersion pins the bound that makes time-travel loads correct: hydrating an
+// aggregate to version N must never start from a snapshot taken after N, or the replay
+// applies events already baked into the snapshot.
+//
+// Reporting ErrSnapshotNotFound is a valid answer here. A store that retains only its
+// newest snapshot has nothing at or below the bound to return, and the caller falls back to
+// full hydration. What the store may not do is answer with a snapshot past the bound.
+func clauseHonorsMaxVersion(t *testing.T, store snapshotstore.SnapshotStore) {
+	aggregateID := newAggregateID()
+	writeVersions(t, store, aggregateID, 1, 2, 3)
+
+	const maxVersion = 2
+
+	snap, err := store.ReadSnapshot(t.Context(), aggregateID, snapshotstore.ReadSnapshotOptions{
+		MaxVersion: maxVersion,
+	})
+	if errors.Is(err, snapshotstore.ErrSnapshotNotFound) {
+		return
+	} else if err != nil {
+		t.Fatalf("reading snapshot with MaxVersion %d: %v", maxVersion, err)
+	}
+
+	if snap.AggregateVersion > maxVersion {
+		t.Errorf("want a snapshot at or below version %d, got version %d", maxVersion, snap.AggregateVersion)
+	}
+}
+
+// clauseSeparatesAggregates pins that snapshots are keyed by the whole aggregate ID. Two
+// aggregates of different types can share a UUID, so a store keying on the UUID alone
+// hands one aggregate the other's state.
+func clauseSeparatesAggregates(t *testing.T, store snapshotstore.SnapshotStore) {
+	snapshotted := newAggregateID()
+	writeVersions(t, store, snapshotted, 1)
+
+	other := typeid.New(snapshotted.Type+"other", snapshotted.UUID)
+
+	if _, err := store.ReadSnapshot(t.Context(), other, snapshotstore.ReadSnapshotOptions{}); !errors.Is(err, snapshotstore.ErrSnapshotNotFound) {
+		t.Errorf("want ErrSnapshotNotFound for an aggregate sharing another's UUID, got %v", err)
+	}
+}
+
+// newAggregateID returns an aggregate ID unique to one clause, so clauses sharing a store
+// cannot observe each other's writes.
+func newAggregateID() typeid.ID {
+	return typeid.NewV4("storetestentity")
+}
+
+func writeVersions(t *testing.T, store snapshotstore.SnapshotStore, aggregateID typeid.ID, versions ...int64) {
+	t.Helper()
+
+	for _, version := range versions {
+		err := store.WriteSnapshot(t.Context(), &snapshotstore.AggregateSnapshot{
+			AggregateID:      aggregateID,
+			AggregateVersion: version,
+			Data:             []byte(`{}`),
+		})
+		if err != nil {
+			t.Fatalf("writing snapshot at version %d: %v", version, err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Moves the store contract into an executable acceptance suite, in core, beside the interfaces it constrains.

## The problem

The contract event stores are written against lived in two places: doc comments on the interfaces, and a 96-line function in `estoria-contrib` that returned an `error`. Core's own reference implementations could not run it — the contract sat downstream of the code it governs. No snapshot store contract existed at all.

That absence is the root cause the review kept landing on. Nothing enforces the extension points, so a backend can drift silently and its own tests stay green.

## Added

**`eventstore/storetest`** (13 clauses) and **`snapshotstore/storetest`** (6 clauses, new). Both report each clause as its own named subtest, so a backend that violates the contract learns *which* clause it broke rather than which line of a linear function returned first.

Clauses cover ground nothing tested before: expected-version match and conflict — including the versions carried on the error — `StreamMustNotExist`, reverse reads, `Count`, metadata round-trip, and the distinction between an absent stream and a read that matched no events.

The snapshot suite deliberately says nothing about retention. Its clauses hold for a store that keeps only its newest snapshot and for one that keeps every snapshot ever written, which is why the `MaxVersion` clause accepts `ErrSnapshotNotFound` as an answer but never a snapshot past the bound.

Both suites are wired into the in-memory stores and the event-stream snapshot store here first. A clause the reference implementation cannot satisfy is a wrong clause, not a wrong store.

## Verification

Every clause was verified by breaking a reference implementation in the way that clause targets and confirming that subtest — and not another — fails. 29 targeted mutations, 28 caught by the clause aimed at them.

The one uncaught mutation is correct rather than a gap: "returns the oldest snapshot" is a no-op against the in-memory store, whose retain-one policy makes oldest and newest the same object. The clause has teeth against the event-stream store, which retains everything, and is caught there.

That exercise found two defects in the suites themselves, neither visible to review:

- **Both round-trip clauses asserted against the struct they had handed the store.** A store that writes through the caller's pointer would edit the expectation into agreeing with whatever it stored, and pass. They now assert against independently rebuilt values, and both suites carry an explicit clause asserting the store does not modify its argument.
- **The expected-version clause held its version assertions inside an `errors.As` branch.** A backend returning that error by pointer satisfies `errors.Is` — the method has a value receiver — but not `errors.As`, so both assertions were skipped with nothing reported. The `As` failure is now fatal, and a mutation returning the error by pointer confirms it.

## Changed

`ReadStream`'s doc comment licensed the ambiguity the suite now forbids, telling consumers to tolerate either answer when a filtered read matches nothing. It states the required behavior instead: an implementation that infers absence from an empty filtered read leaves any aggregate snapshotted at its own stream tip unloadable.

`thelper` is excluded under `storetest/`. Its clause functions take a `*testing.T` but are subtest bodies, and marking them helpers would report every failure at the suite runner's line rather than at the assertion that failed.

## Removed

`EventExistsError`. Nothing in either repository constructs one.

Breaking for anyone referencing the type. `estoria-contrib` carries two deprecated aliases to it, in `sqlite/eventstore` and `postgres/eventstore`, which are the only things that stop compiling.

## Coverage

`eventstore/memory` goes from 92.8% to 97.1%. Both `storetest` packages report 0% and always will — they are test code with no tests of their own.