### PR TITLE
Add tests to cover remaining uncovered packages

### DIFF
--- a/entity_test.go
+++ b/entity_test.go
@@ -1,0 +1,176 @@
+package estoria_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-estoria/estoria"
+	"github.com/go-estoria/estoria/typeid"
+	"github.com/gofrs/uuid/v5"
+)
+
+// mockEntity is value-typed, the shape every entity double in this repo used before the
+// snapshot-corruption fix.
+type mockEntity struct {
+	ID      uuid.UUID `json:"id"`
+	Owner   string    `json:"owner"`
+	Balance int64     `json:"balance"`
+}
+
+func (e mockEntity) EntityID() typeid.ID {
+	return typeid.New("mockentity", e.ID)
+}
+
+// mockPointerEntity is pointer-typed. Marshaling writes through it in place, which is the
+// property that made a failed snapshot decode corrupt live state.
+type mockPointerEntity struct {
+	ID      uuid.UUID `json:"id"`
+	Owner   string    `json:"owner"`
+	Balance int64     `json:"balance"`
+}
+
+func (e *mockPointerEntity) EntityID() typeid.ID {
+	return typeid.New("mockpointerentity", e.ID)
+}
+
+func TestJSONMarshaler_ValueEntity(t *testing.T) {
+	t.Parallel()
+
+	marshaler := estoria.JSONMarshaler[mockEntity]{}
+	want := mockEntity{ID: uuid.Must(uuid.NewV4()), Owner: "alice", Balance: 42}
+
+	data, err := marshaler.MarshalEntity(want)
+	if err != nil {
+		t.Fatalf("marshaling entity: %v", err)
+	}
+
+	var got mockEntity
+	if err := marshaler.UnmarshalEntity(data, &got); err != nil {
+		t.Fatalf("unmarshaling entity: %v", err)
+	}
+
+	if got != want {
+		t.Errorf("want %+v, got %+v", want, got)
+	}
+}
+
+func TestJSONMarshaler_PointerEntity(t *testing.T) {
+	t.Parallel()
+
+	marshaler := estoria.JSONMarshaler[*mockPointerEntity]{}
+	want := &mockPointerEntity{ID: uuid.Must(uuid.NewV4()), Owner: "alice", Balance: 42}
+
+	data, err := marshaler.MarshalEntity(want)
+	if err != nil {
+		t.Fatalf("marshaling entity: %v", err)
+	}
+
+	got := &mockPointerEntity{}
+	if err := marshaler.UnmarshalEntity(data, &got); err != nil {
+		t.Fatalf("unmarshaling entity: %v", err)
+	}
+
+	if *got != *want {
+		t.Errorf("want %+v, got %+v", *want, *got)
+	}
+}
+
+// TestJSONMarshaler_UnmarshalEntity_Invalid pins that a decode failure is reported rather
+// than swallowed. SnapshottingStore relies on the error to decide whether to fall back to
+// full hydration instead of trusting a half-decoded entity.
+func TestJSONMarshaler_UnmarshalEntity_Invalid(t *testing.T) {
+	t.Parallel()
+
+	var dest mockEntity
+	if err := (estoria.JSONMarshaler[mockEntity]{}).UnmarshalEntity([]byte(`{"balance":"not a number"}`), &dest); err == nil {
+		t.Error("want an error for a type-mismatched field, got nil")
+	}
+}
+
+// mockEntityEvent is a minimal EntityEvent used to exercise the event marshaler.
+type mockEntityEvent struct {
+	Amount int64 `json:"amount"`
+}
+
+func (e *mockEntityEvent) EventType() string { return "mockentityevent" }
+
+func (e *mockEntityEvent) New() estoria.EntityEvent[mockEntity] {
+	return &mockEntityEvent{}
+}
+
+func (e *mockEntityEvent) ApplyTo(_ context.Context, entity mockEntity) (mockEntity, error) {
+	entity.Balance += e.Amount
+	return entity, nil
+}
+
+func TestJSONEntityEventMarshaler(t *testing.T) {
+	t.Parallel()
+
+	marshaler := estoria.JSONEntityEventMarshaler[mockEntity]{}
+
+	data, err := marshaler.MarshalEntityEvent(&mockEntityEvent{Amount: 100})
+	if err != nil {
+		t.Fatalf("marshaling entity event: %v", err)
+	}
+
+	got := &mockEntityEvent{}
+	if err := marshaler.UnmarshalEntityEvent(data, got); err != nil {
+		t.Fatalf("unmarshaling entity event: %v", err)
+	}
+
+	if got.Amount != 100 {
+		t.Errorf("want amount 100, got %d", got.Amount)
+	}
+}
+
+// TestJSONEntityEventMarshaler_UnmarshalEntityEvent_Invalid pins that a malformed payload is
+// reported. EventSourcedStore surfaces this as a hydration failure rather than applying an
+// event it could not read.
+func TestJSONEntityEventMarshaler_UnmarshalEntityEvent_Invalid(t *testing.T) {
+	t.Parallel()
+
+	dest := &mockEntityEvent{}
+	if err := (estoria.JSONEntityEventMarshaler[mockEntity]{}).UnmarshalEntityEvent([]byte(`{`), dest); err == nil {
+		t.Error("want an error for malformed JSON, got nil")
+	}
+}
+
+// TestEntityEvent_ApplyTo covers the double satisfying the EntityEvent contract, so the
+// interface's shape is exercised rather than only its marshaling.
+func TestEntityEvent_ApplyTo(t *testing.T) {
+	t.Parallel()
+
+	var event estoria.EntityEvent[mockEntity] = &mockEntityEvent{Amount: 25}
+
+	if got := event.EventType(); got != "mockentityevent" {
+		t.Errorf("want event type %q, got %q", "mockentityevent", got)
+	}
+
+	if got := event.New(); got == nil {
+		t.Error("want a new instance, got nil")
+	}
+
+	got, err := event.ApplyTo(t.Context(), mockEntity{Balance: 100})
+	if err != nil {
+		t.Fatalf("applying event: %v", err)
+	}
+
+	if got.Balance != 125 {
+		t.Errorf("want balance 125, got %d", got.Balance)
+	}
+}
+
+// TestEntityFactory covers the factory signature aggregate stores are constructed with.
+func TestEntityFactory(t *testing.T) {
+	t.Parallel()
+
+	id := uuid.Must(uuid.NewV4())
+
+	var factory estoria.EntityFactory[mockEntity] = func(id uuid.UUID) mockEntity {
+		return mockEntity{ID: id}
+	}
+
+	if got := factory(id); got.EntityID() != typeid.New("mockentity", id) {
+		t.Errorf("want the factory to build an entity carrying the given ID, got %s", got.EntityID())
+	}
+}

--- a/eventstore/event_store_test.go
+++ b/eventstore/event_store_test.go
@@ -1,0 +1,205 @@
+package eventstore_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/go-estoria/estoria/eventstore"
+	"github.com/go-estoria/estoria/typeid"
+)
+
+func TestVersionPtr(t *testing.T) {
+	t.Parallel()
+
+	p := eventstore.VersionPtr(7)
+	if p == nil {
+		t.Fatal("want a non-nil pointer, got nil")
+	}
+
+	if *p != 7 {
+		t.Errorf("want 7, got %d", *p)
+	}
+
+	// Each call must yield its own pointer, or two AppendStreamOptions built from this
+	// helper would alias one version and a write to either would move both.
+	if other := eventstore.VersionPtr(9); other == p {
+		t.Error("want distinct pointers from successive calls, got the same address")
+	}
+}
+
+func TestReadAll(t *testing.T) {
+	t.Parallel()
+
+	t.Run("reads every event up to the end of the stream", func(t *testing.T) {
+		t.Parallel()
+
+		events, err := eventstore.ReadAll(t.Context(), newIterator(3, nil))
+		if err != nil {
+			t.Fatalf("reading events: %v", err)
+		}
+
+		if len(events) != 3 {
+			t.Fatalf("want 3 events, got %d", len(events))
+		}
+
+		for i, event := range events {
+			if want := int64(i + 1); event.StreamVersion != want {
+				t.Errorf("event %d: want stream version %d, got %d", i, want, event.StreamVersion)
+			}
+		}
+	})
+
+	t.Run("returns an empty slice for a stream with no events", func(t *testing.T) {
+		t.Parallel()
+
+		events, err := eventstore.ReadAll(t.Context(), newIterator(0, nil))
+		if err != nil {
+			t.Fatalf("reading events: %v", err)
+		}
+
+		// Empty rather than nil: callers range over the result and check len, and a nil
+		// return would be indistinguishable from a failure that dropped its events.
+		if events == nil {
+			t.Error("want an empty slice, got nil")
+		}
+
+		if len(events) != 0 {
+			t.Errorf("want 0 events, got %d", len(events))
+		}
+	})
+
+	t.Run("returns the events read so far alongside a read failure", func(t *testing.T) {
+		t.Parallel()
+
+		wantErr := errors.New("backend went away")
+
+		events, err := eventstore.ReadAll(t.Context(), newIterator(2, wantErr))
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("want the underlying error to be wrapped, got %v", err)
+		}
+
+		// The partial result is the point: a caller that hits a mid-stream failure can see
+		// how far it got rather than being told only that something broke.
+		if len(events) != 2 {
+			t.Errorf("want the 2 events read before the failure, got %d", len(events))
+		}
+	})
+}
+
+func TestErrorTypes(t *testing.T) {
+	t.Parallel()
+
+	underlying := errors.New("underlying")
+	streamID := typeid.NewV4("stream")
+
+	for _, tt := range []struct {
+		name     string
+		err      error
+		wantMsg  string
+		other    error
+		unwraps  bool
+		matchAll error
+	}{
+		{
+			name:     "EventMarshalingError",
+			err:      eventstore.EventMarshalingError{StreamID: streamID, Err: underlying},
+			wantMsg:  "marshaling event: underlying",
+			other:    eventstore.EventUnmarshalingError{},
+			unwraps:  true,
+			matchAll: eventstore.EventMarshalingError{},
+		},
+		{
+			name:     "EventUnmarshalingError",
+			err:      eventstore.EventUnmarshalingError{StreamID: streamID, Err: underlying},
+			wantMsg:  "unmarshaling event: underlying",
+			other:    eventstore.EventMarshalingError{},
+			unwraps:  true,
+			matchAll: eventstore.EventUnmarshalingError{},
+		},
+		{
+			name:     "InitializationError",
+			err:      eventstore.InitializationError{Err: underlying},
+			wantMsg:  "initializing event store: underlying",
+			other:    eventstore.EventMarshalingError{},
+			unwraps:  true,
+			matchAll: eventstore.InitializationError{},
+		},
+		{
+			name:     "StreamVersionMismatchError",
+			err:      eventstore.StreamVersionMismatchError{StreamID: streamID, ExpectedVersion: 2, ActualVersion: 5},
+			wantMsg:  "stream version mismatch: expected version 2, got version 5",
+			other:    eventstore.InitializationError{},
+			unwraps:  false,
+			matchAll: eventstore.StreamVersionMismatchError{},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := tt.err.Error(); got != tt.wantMsg {
+				t.Errorf("want message %q, got %q", tt.wantMsg, got)
+			}
+
+			// Is matches on type alone, so a zero value of the same type matches a populated
+			// one. That is what lets a caller write errors.Is(err, StreamVersionMismatchError{}).
+			if !errors.Is(tt.err, tt.matchAll) {
+				t.Error("want the error to match a zero value of its own type")
+			}
+
+			if errors.Is(tt.err, tt.other) {
+				t.Errorf("want no match against %T", tt.other)
+			}
+
+			if tt.unwraps && !errors.Is(tt.err, underlying) {
+				t.Error("want the underlying error to be reachable through Unwrap")
+			}
+		})
+	}
+}
+
+// TestStreamVersionMismatchError_As pins that the versions survive errors.As, which is how a
+// caller decides whether to retry and from what version.
+func TestStreamVersionMismatchError_As(t *testing.T) {
+	t.Parallel()
+
+	err := error(eventstore.StreamVersionMismatchError{ExpectedVersion: 2, ActualVersion: 5})
+
+	var mismatch eventstore.StreamVersionMismatchError
+	if !errors.As(err, &mismatch) {
+		t.Fatal("want errors.As to match")
+	}
+
+	if mismatch.ExpectedVersion != 2 || mismatch.ActualVersion != 5 {
+		t.Errorf("want expected 2 and actual 5, got %d and %d", mismatch.ExpectedVersion, mismatch.ActualVersion)
+	}
+}
+
+// iterator yields total events numbered from 1, then either ends the stream or fails.
+type iterator struct {
+	total    int
+	produced int
+	failWith error
+}
+
+func newIterator(total int, failWith error) *iterator {
+	return &iterator{total: total, failWith: failWith}
+}
+
+func (i *iterator) Next(context.Context) (*eventstore.Event, error) {
+	if i.produced == i.total {
+		if i.failWith != nil {
+			return nil, i.failWith
+		}
+
+		return nil, eventstore.ErrEndOfEventStream
+	}
+
+	i.produced++
+
+	return &eventstore.Event{StreamVersion: int64(i.produced)}, nil
+}
+
+func (i *iterator) Close(context.Context) error {
+	return nil
+}

--- a/eventstore/projection/projection_test.go
+++ b/eventstore/projection/projection_test.go
@@ -1,0 +1,266 @@
+package projection_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/go-estoria/estoria"
+	"github.com/go-estoria/estoria/eventstore"
+	"github.com/go-estoria/estoria/eventstore/projection"
+	"github.com/go-estoria/estoria/typeid"
+)
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+
+	t.Run("rejects a nil iterator", func(t *testing.T) {
+		t.Parallel()
+
+		if _, err := projection.New(nil); err == nil {
+			t.Error("want an error for a nil iterator, got nil")
+		}
+	})
+
+	t.Run("accepts an iterator", func(t *testing.T) {
+		t.Parallel()
+
+		p, err := projection.New(newIterator(1))
+		if err != nil {
+			t.Fatalf("creating projection: %v", err)
+		}
+
+		if p == nil {
+			t.Error("want a projection, got nil")
+		}
+	})
+}
+
+func TestStreamProjection_Project(t *testing.T) {
+	t.Parallel()
+
+	t.Run("rejects a nil event handler", func(t *testing.T) {
+		t.Parallel()
+
+		p := newProjection(t, newIterator(1))
+
+		if _, err := p.Project(t.Context(), nil); err == nil {
+			t.Error("want an error for a nil handler, got nil")
+		}
+	})
+
+	t.Run("projects every event in the stream", func(t *testing.T) {
+		t.Parallel()
+
+		var handled int
+
+		p := newProjection(t, newIterator(5))
+
+		result, err := p.Project(t.Context(), projection.EventHandlerFunc(
+			func(context.Context, *eventstore.Event) error {
+				handled++
+				return nil
+			}))
+		if err != nil {
+			t.Fatalf("projecting: %v", err)
+		}
+
+		if handled != 5 {
+			t.Errorf("want the handler called 5 times, got %d", handled)
+		}
+
+		if result.NumProjectedEvents != 5 {
+			t.Errorf("want 5 projected events, got %d", result.NumProjectedEvents)
+		}
+
+		if result.NumFailedEvents != 0 {
+			t.Errorf("want 0 failed events, got %d", result.NumFailedEvents)
+		}
+	})
+
+	t.Run("reports zero projected events for an empty stream", func(t *testing.T) {
+		t.Parallel()
+
+		result, err := newProjection(t, newIterator(0)).Project(t.Context(), failingHandler(t))
+		if err != nil {
+			t.Fatalf("projecting: %v", err)
+		}
+
+		if result.NumProjectedEvents != 0 {
+			t.Errorf("want 0 projected events, got %d", result.NumProjectedEvents)
+		}
+	})
+
+	t.Run("stops at the first handler error by default", func(t *testing.T) {
+		t.Parallel()
+
+		wantErr := errors.New("handler failed")
+
+		var handled int
+
+		result, err := newProjection(t, newIterator(5)).Project(t.Context(), projection.EventHandlerFunc(
+			func(_ context.Context, event *eventstore.Event) error {
+				handled++
+				if event.StreamVersion == 3 {
+					return wantErr
+				}
+
+				return nil
+			}))
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("want the handler error wrapped, got %v", err)
+		}
+
+		// Stopping means stopping: the handler must not see event 4.
+		if handled != 3 {
+			t.Errorf("want the handler called 3 times before stopping, got %d", handled)
+		}
+
+		// The partial result tells a caller how far the projection got.
+		if result.NumProjectedEvents != 2 {
+			t.Errorf("want 2 projected events before the failure, got %d", result.NumProjectedEvents)
+		}
+
+		if result.NumFailedEvents != 1 {
+			t.Errorf("want 1 failed event, got %d", result.NumFailedEvents)
+		}
+	})
+
+	t.Run("continues past handler errors when configured to", func(t *testing.T) {
+		t.Parallel()
+
+		p, err := projection.New(newIterator(5),
+			projection.WithContinueOnHandlerError(true),
+			projection.WithLogger(discardLogger{}),
+		)
+		if err != nil {
+			t.Fatalf("creating projection: %v", err)
+		}
+
+		result, err := p.Project(t.Context(), projection.EventHandlerFunc(
+			func(_ context.Context, event *eventstore.Event) error {
+				if event.StreamVersion%2 == 1 {
+					return errors.New("handler failed")
+				}
+
+				return nil
+			}))
+		if err != nil {
+			t.Fatalf("want the projection to complete, got %v", err)
+		}
+
+		if result.NumProjectedEvents != 2 {
+			t.Errorf("want 2 projected events, got %d", result.NumProjectedEvents)
+		}
+
+		if result.NumFailedEvents != 3 {
+			t.Errorf("want 3 failed events, got %d", result.NumFailedEvents)
+		}
+	})
+
+	t.Run("reports a read failure rather than treating it as the end of the stream", func(t *testing.T) {
+		t.Parallel()
+
+		wantErr := errors.New("backend went away")
+
+		iter := newIterator(2)
+		iter.failWith = wantErr
+
+		result, err := newProjection(t, iter).Project(t.Context(), projection.EventHandlerFunc(
+			func(context.Context, *eventstore.Event) error { return nil }))
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("want the read error wrapped, got %v", err)
+		}
+
+		if result.NumProjectedEvents != 2 {
+			t.Errorf("want the 2 events projected before the failure, got %d", result.NumProjectedEvents)
+		}
+	})
+}
+
+// TestEventHandlerFunc_Handle covers the adapter that lets a bare function satisfy
+// EventHandler.
+func TestEventHandlerFunc_Handle(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("handler failed")
+	wantEvent := &eventstore.Event{StreamID: typeid.NewV4("stream"), StreamVersion: 1}
+
+	var gotEvent *eventstore.Event
+
+	handler := projection.EventHandlerFunc(func(_ context.Context, event *eventstore.Event) error {
+		gotEvent = event
+		return wantErr
+	})
+
+	if err := handler.Handle(t.Context(), wantEvent); !errors.Is(err, wantErr) {
+		t.Errorf("want the function's error returned unchanged, got %v", err)
+	}
+
+	if gotEvent != wantEvent {
+		t.Error("want the event passed through to the function")
+	}
+}
+
+func newProjection(t *testing.T, iter eventstore.StreamIterator) *projection.StreamProjection {
+	t.Helper()
+
+	p, err := projection.New(iter, projection.WithLogger(discardLogger{}))
+	if err != nil {
+		t.Fatalf("creating projection: %v", err)
+	}
+
+	return p
+}
+
+// failingHandler fails the test if it is ever called.
+func failingHandler(t *testing.T) projection.EventHandler {
+	t.Helper()
+
+	return projection.EventHandlerFunc(func(context.Context, *eventstore.Event) error {
+		t.Error("want the handler not to be called")
+		return nil
+	})
+}
+
+// iterator yields total events numbered from 1, then either ends the stream or fails.
+type iterator struct {
+	total    int
+	produced int
+	failWith error
+}
+
+func newIterator(total int) *iterator {
+	return &iterator{total: total}
+}
+
+func (i *iterator) Next(context.Context) (*eventstore.Event, error) {
+	if i.produced == i.total {
+		if i.failWith != nil {
+			return nil, i.failWith
+		}
+
+		return nil, eventstore.ErrEndOfEventStream
+	}
+
+	i.produced++
+
+	return &eventstore.Event{StreamVersion: int64(i.produced)}, nil
+}
+
+func (i *iterator) Close(context.Context) error {
+	return nil
+}
+
+// discardLogger keeps the error path in "continue on handler error" from writing to the
+// test's output, where it reads as a real failure.
+type discardLogger struct{}
+
+var _ estoria.Logger = discardLogger{}
+
+func (discardLogger) Debug(string, ...any)              {}
+func (discardLogger) Info(string, ...any)               {}
+func (discardLogger) Warn(string, ...any)               {}
+func (discardLogger) Error(string, ...any)              {}
+func (l discardLogger) With(...any) estoria.Logger      { return l }
+func (l discardLogger) WithGroup(string) estoria.Logger { return l }

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,0 +1,83 @@
+package estoria_test
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/go-estoria/estoria"
+)
+
+// The logger is package-global, so these tests cannot run in parallel with each other or
+// with anything else that reads it. They restore the original on the way out.
+
+func TestGetLogger_DefaultsToSlog(t *testing.T) {
+	// A nil logger here would panic on the first Debug call anywhere in the library, so the
+	// init-time default is load-bearing rather than cosmetic.
+	if estoria.GetLogger() == nil {
+		t.Fatal("want a logger installed by default, got nil")
+	}
+}
+
+func TestSetLogger(t *testing.T) {
+	original := estoria.GetLogger()
+	t.Cleanup(func() { estoria.SetLogger(original) })
+
+	replacement := &captureLogger{}
+	estoria.SetLogger(replacement)
+
+	if estoria.GetLogger() != replacement {
+		t.Error("want GetLogger to return the logger that was set")
+	}
+
+	estoria.GetLogger().Info("hello")
+
+	if len(replacement.messages) != 1 || replacement.messages[0] != "hello" {
+		t.Errorf("want the message routed to the installed logger, got %v", replacement.messages)
+	}
+}
+
+// TestSlogLogger_WithAndWithGroup covers the two methods SlogLogger adds over slog.Logger.
+// Both exist only to return estoria.Logger rather than *slog.Logger, and both are used
+// throughout the library to tag output by component.
+func TestSlogLogger_WithAndWithGroup(t *testing.T) {
+	var buf bytes.Buffer
+
+	log := estoria.SlogLogger{Logger: slog.New(slog.NewTextHandler(&buf, nil))}
+
+	log.With("key", "value").Info("with message")
+
+	if got := buf.String(); !strings.Contains(got, "key=value") || !strings.Contains(got, "with message") {
+		t.Errorf("want the attribute carried onto the record, got %q", got)
+	}
+
+	buf.Reset()
+
+	log.WithGroup("group").Info("group message", "key", "value")
+
+	if got := buf.String(); !strings.Contains(got, "group.key=value") {
+		t.Errorf("want the attribute namespaced under the group, got %q", got)
+	}
+}
+
+func TestDefaultLogger(t *testing.T) {
+	if estoria.DefaultLogger().Logger == nil {
+		t.Error("want a wrapped slog logger, got nil")
+	}
+}
+
+// captureLogger records the messages it is handed.
+type captureLogger struct {
+	messages []string
+}
+
+var _ estoria.Logger = (*captureLogger)(nil)
+
+func (l *captureLogger) Debug(msg string, _ ...any) { l.messages = append(l.messages, msg) }
+func (l *captureLogger) Info(msg string, _ ...any)  { l.messages = append(l.messages, msg) }
+func (l *captureLogger) Warn(msg string, _ ...any)  { l.messages = append(l.messages, msg) }
+func (l *captureLogger) Error(msg string, _ ...any) { l.messages = append(l.messages, msg) }
+func (l *captureLogger) With(...any) estoria.Logger { return l }
+
+func (l *captureLogger) WithGroup(string) estoria.Logger { return l }

--- a/snapshotstore/snapshot_store_test.go
+++ b/snapshotstore/snapshot_store_test.go
@@ -1,0 +1,165 @@
+package snapshotstore_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-estoria/estoria/snapshotstore"
+	"github.com/go-estoria/estoria/typeid"
+)
+
+// TestEventCountSnapshotPolicy covers the policy that decides when a SnapshottingStore takes
+// a snapshot. Getting N wrong is expensive in both directions: too eager writes a snapshot
+// per save, too lazy replays the whole stream on every cold load.
+func TestEventCountSnapshotPolicy(t *testing.T) {
+	t.Parallel()
+
+	aggregateID := typeid.NewV4("mockentity")
+
+	t.Run("never snapshots when N is zero", func(t *testing.T) {
+		t.Parallel()
+
+		policy := snapshotstore.EventCountSnapshotPolicy{N: 0}
+		for version := int64(0); version <= 10; version++ {
+			if policy.ShouldSnapshot(aggregateID, version, time.Time{}) {
+				t.Errorf("want no snapshot at version %d with N=0", version)
+			}
+		}
+	})
+
+	t.Run("snapshots every Nth version", func(t *testing.T) {
+		t.Parallel()
+
+		policy := snapshotstore.EventCountSnapshotPolicy{N: 3}
+		for version, want := range map[int64]bool{
+			1: false, 2: false, 3: true,
+			4: false, 5: false, 6: true,
+			7: false, 8: false, 9: true,
+		} {
+			if got := policy.ShouldSnapshot(aggregateID, version, time.Time{}); got != want {
+				t.Errorf("version %d: want %v, got %v", version, want, got)
+			}
+		}
+	})
+
+	t.Run("snapshots at every version when N is one", func(t *testing.T) {
+		t.Parallel()
+
+		policy := snapshotstore.EventCountSnapshotPolicy{N: 1}
+		for version := int64(1); version <= 5; version++ {
+			if !policy.ShouldSnapshot(aggregateID, version, time.Time{}) {
+				t.Errorf("want a snapshot at version %d with N=1", version)
+			}
+		}
+	})
+}
+
+// TestMaxSnapshotsRetentionPolicy covers the retention policy the in-memory snapshot store
+// uses. It is called once per snapshot with that snapshot's index and the total, so the
+// decision is positional rather than version-based.
+func TestMaxSnapshotsRetentionPolicy(t *testing.T) {
+	t.Parallel()
+
+	t.Run("retains everything when N is zero", func(t *testing.T) {
+		t.Parallel()
+
+		policy := snapshotstore.MaxSnapshotsRetentionPolicy{N: 0}
+		for index := range int64(5) {
+			if !policy.ShouldRetain(nil, index, 5) {
+				t.Errorf("want index %d retained with N=0", index)
+			}
+		}
+	})
+
+	t.Run("retains only the newest N", func(t *testing.T) {
+		t.Parallel()
+
+		policy := snapshotstore.MaxSnapshotsRetentionPolicy{N: 2}
+		for index, want := range map[int64]bool{0: false, 1: false, 2: false, 3: true, 4: true} {
+			if got := policy.ShouldRetain(nil, index, 5); got != want {
+				t.Errorf("index %d of 5: want %v, got %v", index, want, got)
+			}
+		}
+	})
+
+	t.Run("retains everything when N exceeds the count", func(t *testing.T) {
+		t.Parallel()
+
+		policy := snapshotstore.MaxSnapshotsRetentionPolicy{N: 10}
+		for index := range int64(3) {
+			if !policy.ShouldRetain(nil, index, 3) {
+				t.Errorf("want index %d retained when N exceeds the total", index)
+			}
+		}
+	})
+}
+
+// TestJSONSnapshotMarshaler covers the default marshaler for the event-stream snapshot
+// store, which encodes the whole snapshot envelope into an event payload. Data is []byte,
+// so it goes over the wire base64-encoded and has to survive the round trip intact — a
+// snapshot payload that decodes to different bytes hydrates an aggregate to a corrupt state
+// rather than failing outright.
+func TestJSONSnapshotMarshaler(t *testing.T) {
+	t.Parallel()
+
+	marshaler := snapshotstore.JSONSnapshotMarshaler{}
+	want := &snapshotstore.AggregateSnapshot{
+		AggregateID:      typeid.NewV4("mockentity"),
+		AggregateVersion: 7,
+		Timestamp:        time.Date(2026, time.August, 5, 12, 0, 0, 0, time.UTC),
+		Data:             []byte(`{"owner":"alice","balance":42}`),
+	}
+
+	data, err := marshaler.MarshalSnapshot(want)
+	if err != nil {
+		t.Fatalf("marshaling snapshot: %v", err)
+	}
+
+	got := &snapshotstore.AggregateSnapshot{}
+	if err := marshaler.UnmarshalSnapshot(data, got); err != nil {
+		t.Fatalf("unmarshaling snapshot: %v", err)
+	}
+
+	if got.AggregateID != want.AggregateID {
+		t.Errorf("want aggregate ID %s, got %s", want.AggregateID, got.AggregateID)
+	}
+
+	if got.AggregateVersion != want.AggregateVersion {
+		t.Errorf("want aggregate version %d, got %d", want.AggregateVersion, got.AggregateVersion)
+	}
+
+	if !got.Timestamp.Equal(want.Timestamp) {
+		t.Errorf("want timestamp %s, got %s", want.Timestamp, got.Timestamp)
+	}
+
+	if string(got.Data) != string(want.Data) {
+		t.Errorf("want data %s, got %s", want.Data, got.Data)
+	}
+}
+
+func TestJSONSnapshotMarshaler_UnmarshalSnapshot_Invalid(t *testing.T) {
+	t.Parallel()
+
+	dest := &snapshotstore.AggregateSnapshot{}
+	if err := (snapshotstore.JSONSnapshotMarshaler{}).UnmarshalSnapshot([]byte(`{`), dest); err == nil {
+		t.Error("want an error for malformed JSON, got nil")
+	}
+}
+
+// TestMinAggregateVersionRetentionPolicy covers the version-based alternative, which decides
+// per snapshot rather than by position.
+func TestMinAggregateVersionRetentionPolicy(t *testing.T) {
+	t.Parallel()
+
+	policy := snapshotstore.MinAggregateVersionRetentionPolicy{MinVersion: 5}
+
+	for version, want := range map[int64]bool{3: false, 4: false, 5: true, 6: true} {
+		snap := &snapshotstore.AggregateSnapshot{AggregateVersion: version}
+
+		// Index and total are ignored by this policy; passing values that would flip a
+		// positional policy keeps that explicit.
+		if got := policy.ShouldRetain(snap, 0, 100); got != want {
+			t.Errorf("version %d: want %v, got %v", version, want, got)
+		}
+	}
+}

--- a/typeid/typeid_test.go
+++ b/typeid/typeid_test.go
@@ -1,0 +1,86 @@
+package typeid_test
+
+import (
+	"testing"
+
+	"github.com/go-estoria/estoria/typeid"
+	"github.com/gofrs/uuid/v5"
+)
+
+func TestID_String(t *testing.T) {
+	t.Parallel()
+
+	uid := uuid.Must(uuid.FromString("9791012c-cd5b-4795-9c54-6085975d599b"))
+
+	// The format is load-bearing beyond display: the event-stream snapshot store derives a
+	// stream name from it, and backends key storage on it.
+	if want, got := "user_9791012c-cd5b-4795-9c54-6085975d599b", typeid.New("user", uid).String(); got != want {
+		t.Errorf("want %q, got %q", want, got)
+	}
+}
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+
+	uid := uuid.Must(uuid.NewV4())
+
+	id := typeid.New("user", uid)
+	if id.Type != "user" {
+		t.Errorf("want type %q, got %q", "user", id.Type)
+	}
+
+	if id.UUID != uid {
+		t.Errorf("want UUID %s, got %s", uid, id.UUID)
+	}
+}
+
+func TestNewV4(t *testing.T) {
+	t.Parallel()
+
+	id := typeid.NewV4("user")
+	if id.Type != "user" {
+		t.Errorf("want type %q, got %q", "user", id.Type)
+	}
+
+	if got := id.UUID.Version(); got != 4 {
+		t.Errorf("want a v4 UUID, got version %d", got)
+	}
+
+	if id.UUID.IsNil() {
+		t.Error("want a generated UUID, got the zero value")
+	}
+
+	if other := typeid.NewV4("user"); other.UUID == id.UUID {
+		t.Error("want distinct UUIDs from successive calls, got the same one twice")
+	}
+}
+
+func TestNewV7(t *testing.T) {
+	t.Parallel()
+
+	id := typeid.NewV7("user")
+	if id.Type != "user" {
+		t.Errorf("want type %q, got %q", "user", id.Type)
+	}
+
+	// v7 rather than v4 is the whole reason this constructor exists: the version nibble is
+	// what makes the ID time-ordered and therefore k-sortable in an index.
+	if got := id.UUID.Version(); got != 7 {
+		t.Errorf("want a v7 UUID, got version %d", got)
+	}
+}
+
+// TestNewV7_Sortable pins the property callers actually choose v7 for.
+func TestNewV7_Sortable(t *testing.T) {
+	t.Parallel()
+
+	previous := typeid.NewV7("user")
+	for range 100 {
+		current := typeid.NewV7("user")
+		if current.UUID.String() <= previous.UUID.String() {
+			t.Fatalf("want v7 IDs to sort in creation order, got %s after %s", current.UUID, previous.UUID)
+		}
+
+		previous = current
+	}
+}


### PR DESCRIPTION
## Summary

`estoria`, `eventstore`, `eventstore/projection`, `snapshotstore`, and `typeid` had no test file at all. Each is now at 100% statement coverage.

| Package | Before | After |
|---|---|---|
| `estoria` | 0.0% | 100.0% |
| `eventstore` | 0.0% | 100.0% |
| `eventstore/projection` | 0.0% | 100.0% |
| `snapshotstore` | 0.0% | 100.0% |
| `typeid` | 0.0% | 100.0% |

## Verification

100% coverage proves the lines ran, not that anything was asserted — which is the failure mode a coverage PR is most prone to.

So the tests were checked by mutation: **28 targeted breaks of the code under test, each confirmed to fail the test aimed at it.** Among them — `EventCountSnapshotPolicy` ignoring `N=0`, both retention policies off by one at their boundary, `ReadAll` discarding partial results, `Project` miscounting or continuing when it should stop, `Is` matching every error type, the marshalers swallowing decode errors, and `SetLogger` doing nothing.

## What the tests pin

**`typeid`** — the string format is load-bearing beyond display: the event-stream snapshot store derives a stream name from it and backends key storage on it. `NewV4` and `NewV7` are checked for the version nibble they promise, and v7 additionally for the sort order that is the only reason to choose it over v4.

**`eventstore`** — `ReadAll` returns the events it read alongside a mid-stream failure, so a caller can see how far it got, and returns an empty rather than nil slice for a stream with no events. Error types are checked for message, unwrapping, and that `Is` matches on type without matching everything. `VersionPtr` is checked for returning a fresh pointer per call, since a shared one would alias the expected version across two `AppendStreamOptions`.

**`eventstore/projection`** — `Project` stops at the first handler error by default and does not advance the handler past it, continues and counts failures when configured to, and reports a read failure rather than treating it as the end of the stream. Each case asserts the partial `Result`, which is what tells a caller where it got to.

**`snapshotstore`** — the policies are pinned at their boundaries: `N=0` means never snapshot rather than always, and both retention policies are checked either side of the value they compare against.

**`estoria`** — the marshalers are covered for value and pointer entities, and for reporting decode failures rather than swallowing them. `SnapshottingStore` relies on that error to fall back to full hydration instead of trusting a half-decoded entity, which is the bug fixed in #28. The logger tests deliberately do not run in parallel, because the logger is a package-global they replace and restore.

## One judgment call

`JSONSnapshotMarshaler` is covered even though the serialization work may remove it, because it is live today: it is the default marshaler for `snapshotstore/eventstream`, on the path of every snapshot read and write there. A payload that does not survive the round trip hydrates an aggregate to a corrupt state rather than failing outright. Leaving live code uncovered to avoid writing a test that might later be deleted is the wrong trade.

## Note for any future coverage floor

Both `storetest` packages report 0% and always will — they are test code with no tests of their own. A coverage floor added later has to exclude them or it lands red on arrival.