### PR TITLE
Move identity into the aggregate and distill the core vocabulary

### DIFF
--- a/aggregatestore/aggregate.go
+++ b/aggregatestore/aggregate.go
@@ -10,158 +10,117 @@ import (
 	"github.com/go-estoria/estoria/typeid"
 )
 
-// An Aggregate encapsulates an entity (the aggregate root) and its state.
-type Aggregate[E estoria.Entity] struct {
-	// the aggregate's state (unsaved/unapplied events)
-	state AggregateState[E]
+// An Aggregate is a uniquely identifiable domain object whose state is produced by
+// applying a series of events. It carries the three things that make it one: identity
+// (its typed ID), continuity (its version), and state (the fold over its events).
+type Aggregate[S any] struct {
+	// The aggregate's typed identifier, composed by the store that created it.
+	id typeid.ID
+
+	// The number of events that have been applied to the state.
+	version int64
+
+	// The domain object whose state the aggregate manages.
+	state S
+
+	// Events that have been appended to the aggregate but not yet stored.
+	unsavedEvents []*Event[S]
+
+	// Events that have been loaded from persistence or newly stored but not yet applied to the state.
+	unappliedEvents []*Event[S]
 }
 
-// New creates a new aggregate with the given entity and version.
-func NewAggregate[E estoria.Entity](entity E, version int64) *Aggregate[E] {
-	return &Aggregate[E]{
-		state: AggregateState[E]{
-			entity:  entity,
-			version: version,
-		},
+// newAggregate creates a new aggregate with the given ID, state, and version.
+// Construction is deliberately package-internal: stores compose aggregates, and
+// nothing outside this package builds one.
+func newAggregate[S any](id typeid.ID, state S, version int64) *Aggregate[S] {
+	return &Aggregate[S]{
+		id:      id,
+		version: version,
+		state:   state,
 	}
 }
 
-// Append appends events to the aggregate's unsaved events.
-func (a *Aggregate[E]) Append(events ...estoria.EntityEvent[E]) error {
+// Append appends events to the aggregate's unsaved events, to be persisted and
+// applied on the next save.
+func (a *Aggregate[S]) Append(events ...estoria.DomainEvent[S]) {
 	estoria.GetLogger().Debug("appending events to aggregate", "aggregate_id", a.ID(), "aggregate_version", a.Version(), "events", len(events))
 	for _, event := range events {
-		a.state.WillSave([]*AggregateEvent[E, estoria.EntityEvent[E]]{
-			{
-				ID:          typeid.NewV4(event.EventType()),
-				EntityEvent: event,
-			},
+		a.unsavedEvents = append(a.unsavedEvents, &Event[S]{
+			ID:          typeid.NewV4(event.EventType()),
+			DomainEvent: event,
 		})
 	}
-
-	return nil
 }
 
-// Entity returns the aggregate's underlying entity.
-// The entity is the domain model whose state the aggregate manages.
-//
-//nolint:ireturn // the return type is a type parameter
-func (a *Aggregate[E]) Entity() E {
-	return a.state.Entity()
+// ID returns the aggregate's typed identifier.
+func (a *Aggregate[S]) ID() typeid.ID {
+	return a.id
 }
 
-// ID returns the aggregate's ID.
-// The ID is the ID of the entity that the aggregate represents.
-func (a *Aggregate[E]) ID() typeid.ID {
-	return a.state.Entity().EntityID()
-}
-
-// State returns the aggregate's underlying state, allowinig access to lower
-// level operations on the aggregate's unsaved events and unapplied events.
-//
-// State management is useful when implementing custom aggregate store
-// functionality; it is typically not needed when using an aggregate store
-// to load and save aggregates.
-func (a *Aggregate[E]) State() *AggregateState[E] {
-	return &a.state
+// State returns the aggregate's state.
+// The state is the domain model whose evolution the aggregate manages.
+func (a *Aggregate[S]) State() S {
+	return a.state
 }
 
 // Version returns the aggregate's version.
 // The version is the number of events that have been applied to the aggregate.
 // An aggregate with no events has a version of 0.
-func (a *Aggregate[E]) Version() int64 {
-	return a.state.Version()
+func (a *Aggregate[S]) Version() int64 {
+	return a.version
 }
 
-// AggregateState holds all of the aggregate's state, including the entity, version,
-// unsaved events, and unapplied events.
-type AggregateState[E estoria.Entity] struct {
-	// The domain object whose state the aggregate manages.
-	entity E
-
-	// The number of events that have been applied to the entity.
-	version int64
-
-	// Events that have been appended to the aggregate but not yet stored.
-	unsavedEvents []*AggregateEvent[E, estoria.EntityEvent[E]]
-
-	// Events that have been loaded from persistence or newly stored but not yet applied to the entity.
-	unappliedEvents []*AggregateEvent[E, estoria.EntityEvent[E]]
-}
-
-// ApplyNext applies the next entity event in the apply queue to the entity.
+// applyNext applies the next domain event in the apply queue to the state.
 // A successfully applied event increments the aggregate's version. If
 // there are no events in the apply queue, ErrNoUnappliedEvents is returned.
-func (a *AggregateState[E]) ApplyNext(ctx context.Context) error {
+func (a *Aggregate[S]) applyNext(ctx context.Context) error {
 	if len(a.unappliedEvents) == 0 {
 		return ErrNoUnappliedEvents
 	} else if a.unappliedEvents[0].Version != a.version+1 {
 		return fmt.Errorf("event version mismatch: expected %d, got %d", a.version+1, a.unappliedEvents[0].Version)
 	}
 
-	entity, err := a.unappliedEvents[0].EntityEvent.ApplyTo(ctx, a.entity)
+	state, err := a.unappliedEvents[0].DomainEvent.ApplyTo(ctx, a.state)
 	if err != nil {
 		return fmt.Errorf("applying event: %w", err)
 	}
 
-	a.entity = entity
+	a.state = state
 	a.version = a.unappliedEvents[0].Version
 	a.unappliedEvents = a.unappliedEvents[1:]
 
 	return nil
 }
 
-// ClearUnsavedEvents clears the aggregate's unsaved events.
-func (a *AggregateState[E]) ClearUnsavedEvents() {
+// clearUnsavedEvents clears the aggregate's unsaved events.
+func (a *Aggregate[S]) clearUnsavedEvents() {
 	a.unsavedEvents = nil
 }
 
-// WillApply appends an aggregate event to be applied to
-// the aggregate during subsequent calls to ApplyNext.
-func (a *AggregateState[E]) WillApply(event *AggregateEvent[E, estoria.EntityEvent[E]]) {
-	a.unappliedEvents = append(a.unappliedEvents, event)
-}
-
-// WillSave appends aggregate events to be saved on the next call to Save.
-func (a *AggregateState[E]) WillSave(events []*AggregateEvent[E, estoria.EntityEvent[E]]) {
-	a.unsavedEvents = append(a.unsavedEvents, events...)
-}
-
-// Entity returns the aggregate's entity.
-//
-//nolint:ireturn // the return type is a type parameter
-func (a *AggregateState[E]) Entity() E {
-	return a.entity
-}
-
-// SetEntityAtVersion sets the aggregate's entity and version.
-func (a *AggregateState[E]) SetEntityAtVersion(entity E, version int64) {
-	a.entity = entity
+// setStateAtVersion sets the aggregate's state and version.
+func (a *Aggregate[S]) setStateAtVersion(state S, version int64) {
+	a.state = state
 	a.version = version
 }
 
-// UnsavedEvents returns the unsaved events for the aggregate.
-// These are events that have been appended to the aggregate but not yet saved.
-// They are thus not yet applied to the aggregate's entity.
-func (a *AggregateState[E]) UnsavedEvents() []*AggregateEvent[E, estoria.EntityEvent[E]] {
-	return a.unsavedEvents
+// willApply appends an event to be applied to the aggregate during subsequent
+// calls to applyNext.
+func (a *Aggregate[S]) willApply(event *Event[S]) {
+	a.unappliedEvents = append(a.unappliedEvents, event)
 }
 
-// Version returns the aggregate's version.
-func (a *AggregateState[E]) Version() int64 {
-	return a.version
-}
-
-// An AggregateEvent is an event that applies to an aggregate to change its state.
-// It consists of a unique ID, a timestamp, and an entity event, which holds data specific
-// to an event representinig an incremental change to the underlying entity.
-type AggregateEvent[E estoria.Entity, EE estoria.EntityEvent[E]] struct {
+// An Event is an event that applies to an aggregate to change its state.
+// It consists of a unique ID, a timestamp, and a domain event, which holds data
+// specific to an event representing an incremental change to the underlying state.
+type Event[S any] struct {
 	ID          typeid.ID
 	Version     int64
 	Timestamp   time.Time
-	EntityEvent EE
+	DomainEvent estoria.DomainEvent[S]
 }
 
 // ErrNoUnappliedEvents indicates that there are no unapplied events for the aggregate.
-// This error is returned by ApplyNext when there are no events in the apply queue.
-// It should be handled by the caller as a normal condition.
+// It is returned when applying events to an aggregate whose apply queue is empty and
+// should be handled as a normal condition.
 var ErrNoUnappliedEvents = errors.New("no unapplied events")

--- a/aggregatestore/aggregate_store.go
+++ b/aggregatestore/aggregate_store.go
@@ -4,17 +4,19 @@ import (
 	"context"
 	"errors"
 
-	"github.com/go-estoria/estoria"
 	"github.com/go-estoria/estoria/typeid"
 	"github.com/gofrs/uuid/v5"
 )
 
 // A Store is a read/write store for aggregates.
-type Store[E estoria.Entity] interface {
-	New(id uuid.UUID) *Aggregate[E]
-	Load(ctx context.Context, id uuid.UUID, opts *LoadOptions) (*Aggregate[E], error)
-	Hydrate(ctx context.Context, aggregate *Aggregate[E], opts *HydrateOptions) error
-	Save(ctx context.Context, aggregate *Aggregate[E], opts *SaveOptions) error
+type Store[S any] interface {
+	// AggregateType returns the aggregate type name used to compose the typed IDs
+	// under which the store's aggregates are addressed.
+	AggregateType() string
+	New(id uuid.UUID) *Aggregate[S]
+	Load(ctx context.Context, id uuid.UUID, opts *LoadOptions) (*Aggregate[S], error)
+	Hydrate(ctx context.Context, aggregate *Aggregate[S], opts *HydrateOptions) error
+	Save(ctx context.Context, aggregate *Aggregate[S], opts *SaveOptions) error
 }
 
 // LoadOptions are options for loading an aggregate.

--- a/aggregatestore/aggregate_store_test.go
+++ b/aggregatestore/aggregate_store_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/go-estoria/estoria"
 	"github.com/go-estoria/estoria/aggregatestore"
 	"github.com/go-estoria/estoria/typeid"
 	"github.com/gofrs/uuid/v5"
@@ -12,14 +11,23 @@ import (
 
 // Mocks in this file are shared by the tests for multiple aggregate store implementations.
 
-type mockAggregateStore[E estoria.Entity] struct {
-	NewFn     func(uuid.UUID) *aggregatestore.Aggregate[E]
-	LoadFn    func(context.Context, uuid.UUID, *aggregatestore.LoadOptions) (*aggregatestore.Aggregate[E], error)
-	HydrateFn func(context.Context, *aggregatestore.Aggregate[E], *aggregatestore.HydrateOptions) error
-	SaveFn    func(context.Context, *aggregatestore.Aggregate[E], *aggregatestore.SaveOptions) error
+type mockAggregateStore[S any] struct {
+	AggregateTypeFn func() string
+	NewFn           func(uuid.UUID) *aggregatestore.Aggregate[S]
+	LoadFn          func(context.Context, uuid.UUID, *aggregatestore.LoadOptions) (*aggregatestore.Aggregate[S], error)
+	HydrateFn       func(context.Context, *aggregatestore.Aggregate[S], *aggregatestore.HydrateOptions) error
+	SaveFn          func(context.Context, *aggregatestore.Aggregate[S], *aggregatestore.SaveOptions) error
 }
 
-func (s *mockAggregateStore[E]) New(id uuid.UUID) *aggregatestore.Aggregate[E] {
+func (s *mockAggregateStore[S]) AggregateType() string {
+	if s.AggregateTypeFn != nil {
+		return s.AggregateTypeFn()
+	}
+
+	return "mockentity"
+}
+
+func (s *mockAggregateStore[S]) New(id uuid.UUID) *aggregatestore.Aggregate[S] {
 	if s.NewFn != nil {
 		return s.NewFn(id)
 	}
@@ -27,7 +35,7 @@ func (s *mockAggregateStore[E]) New(id uuid.UUID) *aggregatestore.Aggregate[E] {
 	return nil
 }
 
-func (s *mockAggregateStore[E]) Load(ctx context.Context, aggregateID uuid.UUID, opts *aggregatestore.LoadOptions) (*aggregatestore.Aggregate[E], error) {
+func (s *mockAggregateStore[S]) Load(ctx context.Context, aggregateID uuid.UUID, opts *aggregatestore.LoadOptions) (*aggregatestore.Aggregate[S], error) {
 	if s.LoadFn != nil {
 		return s.LoadFn(ctx, aggregateID, opts)
 	}
@@ -35,7 +43,7 @@ func (s *mockAggregateStore[E]) Load(ctx context.Context, aggregateID uuid.UUID,
 	return nil, fmt.Errorf("unexpected call: Load(aggregateID=%s, opts=%v)", aggregateID, opts)
 }
 
-func (s *mockAggregateStore[E]) Hydrate(ctx context.Context, aggregate *aggregatestore.Aggregate[E], opts *aggregatestore.HydrateOptions) error {
+func (s *mockAggregateStore[S]) Hydrate(ctx context.Context, aggregate *aggregatestore.Aggregate[S], opts *aggregatestore.HydrateOptions) error {
 	if s.HydrateFn != nil {
 		return s.HydrateFn(ctx, aggregate, opts)
 	}
@@ -43,7 +51,7 @@ func (s *mockAggregateStore[E]) Hydrate(ctx context.Context, aggregate *aggregat
 	return fmt.Errorf("unexpected call: Hydrate(aggregate=%v, opts=%v)", aggregate, opts)
 }
 
-func (s *mockAggregateStore[E]) Save(ctx context.Context, aggregate *aggregatestore.Aggregate[E], opts *aggregatestore.SaveOptions) error {
+func (s *mockAggregateStore[S]) Save(ctx context.Context, aggregate *aggregatestore.Aggregate[S], opts *aggregatestore.SaveOptions) error {
 	if s.SaveFn != nil {
 		return s.SaveFn(ctx, aggregate, opts)
 	}
@@ -57,8 +65,6 @@ type mockEntity struct {
 	lastValueEventValue string
 }
 
-var _ estoria.Entity = mockEntity{}
-
 func newMockEntity(id uuid.UUID) mockEntity {
 	return mockEntity{
 		ID: typeid.New("mockentity", id),
@@ -67,4 +73,10 @@ func newMockEntity(id uuid.UUID) mockEntity {
 
 func (e mockEntity) EntityID() typeid.ID {
 	return e.ID
+}
+
+// newMockAggregate builds an aggregate the way a store would: the typed ID composed
+// from the aggregate type name and the UUID, the state from the factory, at a version.
+func newMockAggregate(id uuid.UUID, version int64) *aggregatestore.Aggregate[mockEntity] {
+	return aggregatestore.NewAggregateForTest(typeid.New("mockentity", id), newMockEntity(id), version)
 }

--- a/aggregatestore/cached_store.go
+++ b/aggregatestore/cached_store.go
@@ -9,27 +9,36 @@ import (
 	"github.com/gofrs/uuid/v5"
 )
 
+// A CachedAggregate is what a cache holds for an aggregate: its state and the version
+// that state reflects. Identity is not part of the entry — entries are keyed by typed
+// ID, and CachedStore composes the aggregate from the key and the entry on a hit.
+type CachedAggregate[S any] struct {
+	State   S
+	Version int64
+}
+
 // An AggregateCache is a cache for aggregates.
 //
-// Aggregates are keyed by their typed ID rather than a bare UUID so that a cache backend
-// shared across aggregate types produces distinct, self-describing keys.
-type AggregateCache[E estoria.Entity] interface {
-	GetAggregate(ctx context.Context, aggregateID typeid.ID) (*Aggregate[E], error)
-	PutAggregate(ctx context.Context, aggregate *Aggregate[E]) error
+// Entries are keyed by their typed ID rather than a bare UUID so that a cache backend
+// shared across aggregate types produces distinct, self-describing keys. A get that
+// finds nothing returns a nil entry and a nil error.
+type AggregateCache[S any] interface {
+	GetAggregate(ctx context.Context, aggregateID typeid.ID) (*CachedAggregate[S], error)
+	PutAggregate(ctx context.Context, aggregateID typeid.ID, entry CachedAggregate[S]) error
 }
 
 // CachedStore wraps an aggreate store with an AggregateCache to cache aggregates.
-type CachedStore[E estoria.Entity] struct {
-	inner Store[E]
-	cache AggregateCache[E]
+type CachedStore[S any] struct {
+	inner Store[S]
+	cache AggregateCache[S]
 	log   estoria.Logger
 }
 
 // NewCachedStore creates a new CachedStore.
-func NewCachedStore[E estoria.Entity](
-	inner Store[E],
-	cacher AggregateCache[E],
-) (*CachedStore[E], error) {
+func NewCachedStore[S any](
+	inner Store[S],
+	cacher AggregateCache[S],
+) (*CachedStore[S], error) {
 	switch {
 	case inner == nil:
 		return nil, errors.New("inner store is required")
@@ -37,17 +46,22 @@ func NewCachedStore[E estoria.Entity](
 		return nil, errors.New("aggregate cache is required")
 	}
 
-	return &CachedStore[E]{
+	return &CachedStore[S]{
 		inner: inner,
 		cache: cacher,
 		log:   estoria.GetLogger().WithGroup("cachedstore"),
 	}, nil
 }
 
-var _ Store[estoria.Entity] = (*CachedStore[estoria.Entity])(nil)
+var _ Store[struct{}] = (*CachedStore[struct{}])(nil)
+
+// AggregateType returns the aggregate type name of the inner store.
+func (s *CachedStore[S]) AggregateType() string {
+	return s.inner.AggregateType()
+}
 
 // New creates a new aggregate with the given ID.
-func (s *CachedStore[E]) New(id uuid.UUID) *Aggregate[E] {
+func (s *CachedStore[S]) New(id uuid.UUID) *Aggregate[S] {
 	return s.inner.New(id)
 }
 
@@ -57,7 +71,7 @@ func (s *CachedStore[E]) New(id uuid.UUID) *Aggregate[E] {
 // holds whatever version an aggregate was last saved or loaded at, which is not necessarily
 // the requested one, and writing a deliberately-truncated aggregate back would then serve
 // that stale version to subsequent full loads.
-func (s *CachedStore[E]) Load(ctx context.Context, id uuid.UUID, opts *LoadOptions) (*Aggregate[E], error) {
+func (s *CachedStore[S]) Load(ctx context.Context, id uuid.UUID, opts *LoadOptions) (*Aggregate[S], error) {
 	if opts != nil && opts.ToVersion > 0 {
 		s.log.Debug("bypassing cache for versioned load", "aggregate_id", id, "to_version", opts.ToVersion)
 
@@ -69,24 +83,24 @@ func (s *CachedStore[E]) Load(ctx context.Context, id uuid.UUID, opts *LoadOptio
 		return aggregate, nil
 	}
 
-	aggregateID := s.inner.New(id).ID()
+	aggregateID := typeid.New(s.inner.AggregateType(), id)
 
-	aggregate, err := s.cache.GetAggregate(ctx, aggregateID)
+	entry, err := s.cache.GetAggregate(ctx, aggregateID)
 	switch {
-	case err == nil && aggregate != nil:
-		return aggregate, nil
+	case err == nil && entry != nil:
+		return newAggregate(aggregateID, entry.State, entry.Version), nil
 	case err != nil:
 		s.log.Warn("failed to read cache", "aggregate_id", aggregateID, "error", err)
-	case aggregate == nil:
+	default:
 		s.log.Debug("aggregate not in cache", "aggregate_id", aggregateID)
 	}
 
-	aggregate, err = s.inner.Load(ctx, id, opts)
+	aggregate, err := s.inner.Load(ctx, id, opts)
 	if err != nil {
 		return nil, LoadError{Operation: "loading from inner aggregate store", Err: err}
 	}
 
-	if err := s.cache.PutAggregate(ctx, aggregate); err != nil {
+	if err := s.cache.PutAggregate(ctx, aggregate.ID(), CachedAggregate[S]{State: aggregate.State(), Version: aggregate.Version()}); err != nil {
 		s.log.Warn("failed to write cache", "aggregate_id", aggregateID, "error", err)
 	}
 
@@ -94,12 +108,12 @@ func (s *CachedStore[E]) Load(ctx context.Context, id uuid.UUID, opts *LoadOptio
 }
 
 // Hydrate hydrates an aggregate by deferring to the inner store.
-func (s *CachedStore[E]) Hydrate(ctx context.Context, aggregate *Aggregate[E], opts *HydrateOptions) error {
+func (s *CachedStore[S]) Hydrate(ctx context.Context, aggregate *Aggregate[S], opts *HydrateOptions) error {
 	return s.inner.Hydrate(ctx, aggregate, opts)
 }
 
 // Save saves an aggregate using the inner store, then updates the cache.
-func (s *CachedStore[E]) Save(ctx context.Context, aggregate *Aggregate[E], opts *SaveOptions) error {
+func (s *CachedStore[S]) Save(ctx context.Context, aggregate *Aggregate[S], opts *SaveOptions) error {
 	if aggregate == nil {
 		return SaveError{Err: ErrNilAggregate}
 	}
@@ -108,17 +122,17 @@ func (s *CachedStore[E]) Save(ctx context.Context, aggregate *Aggregate[E], opts
 		return SaveError{AggregateID: aggregate.ID(), Operation: "saving to inner aggregate store", Err: err}
 	}
 
-	// An aggregate saved with SkipApply still has events queued, so its entity and version
+	// An aggregate saved with SkipApply still has events queued, so its state and version
 	// trail what was just persisted. Caching it would serve that trailing state to later
 	// loads, so leave the previous entry alone and let the next load repopulate it.
-	if len(aggregate.state.unappliedEvents) > 0 {
+	if len(aggregate.unappliedEvents) > 0 {
 		s.log.Debug("skipping cache write for aggregate with unapplied events",
 			"aggregate_id", aggregate.ID(),
-			"unapplied_events", len(aggregate.state.unappliedEvents))
+			"unapplied_events", len(aggregate.unappliedEvents))
 		return nil
 	}
 
-	if err := s.cache.PutAggregate(ctx, aggregate); err != nil {
+	if err := s.cache.PutAggregate(ctx, aggregate.ID(), CachedAggregate[S]{State: aggregate.State(), Version: aggregate.Version()}); err != nil {
 		s.log.Warn("failed to write cache", "aggregate_id", aggregate.ID(), "error", err)
 	}
 

--- a/aggregatestore/cached_store_test.go
+++ b/aggregatestore/cached_store_test.go
@@ -6,21 +6,20 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/go-estoria/estoria"
 	"github.com/go-estoria/estoria/aggregatestore"
 	"github.com/go-estoria/estoria/typeid"
 	"github.com/gofrs/uuid/v5"
 )
 
 // mockCache is a mock implementation of aggregatestore.AggregateCache.
-type mockCache[E estoria.Entity] struct {
-	GetAggregateFn func(context.Context, typeid.ID) (*aggregatestore.Aggregate[E], error)
-	PutAggregateFn func(context.Context, *aggregatestore.Aggregate[E]) error
+type mockCache[E any] struct {
+	GetAggregateFn func(context.Context, typeid.ID) (*aggregatestore.CachedAggregate[E], error)
+	PutAggregateFn func(context.Context, typeid.ID, aggregatestore.CachedAggregate[E]) error
 }
 
 var _ aggregatestore.AggregateCache[mockEntity] = (*mockCache[mockEntity])(nil)
 
-func (c *mockCache[E]) GetAggregate(ctx context.Context, id typeid.ID) (*aggregatestore.Aggregate[E], error) {
+func (c *mockCache[E]) GetAggregate(ctx context.Context, id typeid.ID) (*aggregatestore.CachedAggregate[E], error) {
 	if c.GetAggregateFn != nil {
 		return c.GetAggregateFn(ctx, id)
 	}
@@ -28,12 +27,12 @@ func (c *mockCache[E]) GetAggregate(ctx context.Context, id typeid.ID) (*aggrega
 	return nil, fmt.Errorf("unexpected call: GetAggregate(id=%s)", id)
 }
 
-func (c *mockCache[E]) PutAggregate(ctx context.Context, aggregate *aggregatestore.Aggregate[E]) error {
+func (c *mockCache[E]) PutAggregate(ctx context.Context, id typeid.ID, entry aggregatestore.CachedAggregate[E]) error {
 	if c.PutAggregateFn != nil {
-		return c.PutAggregateFn(ctx, aggregate)
+		return c.PutAggregateFn(ctx, id, entry)
 	}
 
-	return fmt.Errorf("unexpected call: PutAggregate(aggregate=%v)", nil)
+	return fmt.Errorf("unexpected call: PutAggregate(id=%s, entry=%v)", id, entry)
 }
 
 func TestNewCachedStore(t *testing.T) {
@@ -92,19 +91,19 @@ func TestCachedStore_Load(t *testing.T) {
 			haveInner: func() aggregatestore.Store[mockEntity] {
 				return &mockAggregateStore[mockEntity]{
 					NewFn: func(id uuid.UUID) *aggregatestore.Aggregate[mockEntity] {
-						return aggregatestore.NewAggregate(newMockEntity(id), 0)
+						return newMockAggregate(id, 0)
 					},
 				}
 			},
 			haveCache: func() aggregatestore.AggregateCache[mockEntity] {
 				return &mockCache[mockEntity]{
-					GetAggregateFn: func(_ context.Context, id typeid.ID) (*aggregatestore.Aggregate[mockEntity], error) {
-						return aggregatestore.NewAggregate(newMockEntity(id.UUID), 42), nil
+					GetAggregateFn: func(_ context.Context, id typeid.ID) (*aggregatestore.CachedAggregate[mockEntity], error) {
+						return &aggregatestore.CachedAggregate[mockEntity]{State: newMockEntity(id.UUID), Version: 42}, nil
 					},
 				}
 			},
 			wantAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID), 42)
+				return newMockAggregate(aggregateID, 42)
 			}(),
 		},
 		{
@@ -112,22 +111,22 @@ func TestCachedStore_Load(t *testing.T) {
 			haveInner: func() aggregatestore.Store[mockEntity] {
 				return &mockAggregateStore[mockEntity]{
 					NewFn: func(id uuid.UUID) *aggregatestore.Aggregate[mockEntity] {
-						return aggregatestore.NewAggregate(newMockEntity(id), 0)
+						return newMockAggregate(id, 0)
 					},
 					LoadFn: func(_ context.Context, id uuid.UUID, _ *aggregatestore.LoadOptions) (*aggregatestore.Aggregate[mockEntity], error) {
-						return aggregatestore.NewAggregate(newMockEntity(id), 42), nil
+						return newMockAggregate(id, 42), nil
 					},
 				}
 			},
 			haveCache: func() aggregatestore.AggregateCache[mockEntity] {
 				return &mockCache[mockEntity]{
-					GetAggregateFn: func(context.Context, typeid.ID) (*aggregatestore.Aggregate[mockEntity], error) {
+					GetAggregateFn: func(context.Context, typeid.ID) (*aggregatestore.CachedAggregate[mockEntity], error) {
 						return nil, nil
 					},
 				}
 			},
 			wantAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID), 42)
+				return newMockAggregate(aggregateID, 42)
 			}(),
 		},
 		{
@@ -135,22 +134,22 @@ func TestCachedStore_Load(t *testing.T) {
 			haveInner: func() aggregatestore.Store[mockEntity] {
 				return &mockAggregateStore[mockEntity]{
 					NewFn: func(id uuid.UUID) *aggregatestore.Aggregate[mockEntity] {
-						return aggregatestore.NewAggregate(newMockEntity(id), 0)
+						return newMockAggregate(id, 0)
 					},
 					LoadFn: func(_ context.Context, id uuid.UUID, _ *aggregatestore.LoadOptions) (*aggregatestore.Aggregate[mockEntity], error) {
-						return aggregatestore.NewAggregate(newMockEntity(id), 42), nil
+						return newMockAggregate(id, 42), nil
 					},
 				}
 			},
 			haveCache: func() aggregatestore.AggregateCache[mockEntity] {
 				return &mockCache[mockEntity]{
-					GetAggregateFn: func(context.Context, typeid.ID) (*aggregatestore.Aggregate[mockEntity], error) {
+					GetAggregateFn: func(context.Context, typeid.ID) (*aggregatestore.CachedAggregate[mockEntity], error) {
 						return nil, errors.New("mock error")
 					},
 				}
 			},
 			wantAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID), 42)
+				return newMockAggregate(aggregateID, 42)
 			}(),
 		},
 		{
@@ -158,7 +157,7 @@ func TestCachedStore_Load(t *testing.T) {
 			haveInner: func() aggregatestore.Store[mockEntity] {
 				return &mockAggregateStore[mockEntity]{
 					NewFn: func(id uuid.UUID) *aggregatestore.Aggregate[mockEntity] {
-						return aggregatestore.NewAggregate(newMockEntity(id), 0)
+						return newMockAggregate(id, 0)
 					},
 					LoadFn: func(context.Context, uuid.UUID, *aggregatestore.LoadOptions) (*aggregatestore.Aggregate[mockEntity], error) {
 						return nil, errors.New("mock error")
@@ -167,7 +166,7 @@ func TestCachedStore_Load(t *testing.T) {
 			},
 			haveCache: func() aggregatestore.AggregateCache[mockEntity] {
 				return &mockCache[mockEntity]{
-					GetAggregateFn: func(context.Context, typeid.ID) (*aggregatestore.Aggregate[mockEntity], error) {
+					GetAggregateFn: func(context.Context, typeid.ID) (*aggregatestore.CachedAggregate[mockEntity], error) {
 						return nil, nil
 					},
 				}
@@ -231,7 +230,7 @@ func TestCachedStore_Hydrate(t *testing.T) {
 			haveInner: func() aggregatestore.Store[mockEntity] {
 				return &mockAggregateStore[mockEntity]{
 					HydrateFn: func(_ context.Context, aggregate *aggregatestore.Aggregate[mockEntity], _ *aggregatestore.HydrateOptions) error {
-						aggregate.State().SetEntityAtVersion(newMockEntity(aggregateID), 42)
+						aggregate.TestOnlySetStateAtVersion(newMockEntity(aggregateID), 42)
 						return nil
 					},
 				}
@@ -240,10 +239,10 @@ func TestCachedStore_Hydrate(t *testing.T) {
 				return &mockCache[mockEntity]{}
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID), 0)
+				return newMockAggregate(aggregateID, 0)
 			},
 			wantAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID), 42)
+				return newMockAggregate(aggregateID, 42)
 			}(),
 		},
 		{
@@ -322,26 +321,26 @@ func TestCachedStore_Save(t *testing.T) {
 			haveInner: func() aggregatestore.Store[mockEntity] {
 				return &mockAggregateStore[mockEntity]{
 					SaveFn: func(_ context.Context, aggregate *aggregatestore.Aggregate[mockEntity], _ *aggregatestore.SaveOptions) error {
-						aggregate.State().SetEntityAtVersion(newMockEntity(aggregateID), 42)
+						aggregate.TestOnlySetStateAtVersion(newMockEntity(aggregateID), 42)
 						return nil
 					},
 				}
 			},
 			haveCache: func() aggregatestore.AggregateCache[mockEntity] {
 				return &mockCache[mockEntity]{
-					PutAggregateFn: func(context.Context, *aggregatestore.Aggregate[mockEntity]) error {
+					PutAggregateFn: func(context.Context, typeid.ID, aggregatestore.CachedAggregate[mockEntity]) error {
 						return nil
 					},
 				}
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID), 0)
+				return newMockAggregate(aggregateID, 0)
 			},
 			wantAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID), 42)
+				return newMockAggregate(aggregateID, 42)
 			}(),
 			wantCachedAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID), 42)
+				return newMockAggregate(aggregateID, 42)
 			}(),
 		},
 		{
@@ -357,7 +356,7 @@ func TestCachedStore_Save(t *testing.T) {
 				return &mockCache[mockEntity]{}
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID), 42)
+				return newMockAggregate(aggregateID, 42)
 			},
 			wantErr: errors.New("saving to inner aggregate store: mock error"),
 		},
@@ -366,23 +365,23 @@ func TestCachedStore_Save(t *testing.T) {
 			haveInner: func() aggregatestore.Store[mockEntity] {
 				return &mockAggregateStore[mockEntity]{
 					SaveFn: func(_ context.Context, aggregate *aggregatestore.Aggregate[mockEntity], _ *aggregatestore.SaveOptions) error {
-						aggregate.State().SetEntityAtVersion(newMockEntity(aggregateID), 42)
+						aggregate.TestOnlySetStateAtVersion(newMockEntity(aggregateID), 42)
 						return nil
 					},
 				}
 			},
 			haveCache: func() aggregatestore.AggregateCache[mockEntity] {
 				return &mockCache[mockEntity]{
-					PutAggregateFn: func(context.Context, *aggregatestore.Aggregate[mockEntity]) error {
+					PutAggregateFn: func(context.Context, typeid.ID, aggregatestore.CachedAggregate[mockEntity]) error {
 						return errors.New("mock error")
 					},
 				}
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID), 0)
+				return newMockAggregate(aggregateID, 0)
 			},
 			wantAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID), 42)
+				return newMockAggregate(aggregateID, 42)
 			}(),
 		},
 	} {
@@ -459,22 +458,22 @@ func TestCachedStore_Load_BypassesCacheForVersionedLoad(t *testing.T) {
 
 	inner := &mockAggregateStore[mockEntity]{
 		NewFn: func(id uuid.UUID) *aggregatestore.Aggregate[mockEntity] {
-			return aggregatestore.NewAggregate(newMockEntity(id), 0)
+			return newMockAggregate(id, 0)
 		},
 		LoadFn: func(_ context.Context, id uuid.UUID, opts *aggregatestore.LoadOptions) (*aggregatestore.Aggregate[mockEntity], error) {
 			if opts == nil || opts.ToVersion == 0 {
-				return aggregatestore.NewAggregate(newMockEntity(id), 10), nil
+				return newMockAggregate(id, 10), nil
 			}
-			return aggregatestore.NewAggregate(newMockEntity(id), opts.ToVersion), nil
+			return newMockAggregate(id, opts.ToVersion), nil
 		},
 	}
 
 	cache := &mockCache[mockEntity]{
-		GetAggregateFn: func(_ context.Context, id typeid.ID) (*aggregatestore.Aggregate[mockEntity], error) {
+		GetAggregateFn: func(_ context.Context, id typeid.ID) (*aggregatestore.CachedAggregate[mockEntity], error) {
 			cacheReads++
-			return aggregatestore.NewAggregate(newMockEntity(id.UUID), 10), nil
+			return &aggregatestore.CachedAggregate[mockEntity]{State: newMockEntity(id.UUID), Version: 10}, nil
 		},
-		PutAggregateFn: func(context.Context, *aggregatestore.Aggregate[mockEntity]) error {
+		PutAggregateFn: func(context.Context, typeid.ID, aggregatestore.CachedAggregate[mockEntity]) error {
 			cacheWrites++
 			return nil
 		},

--- a/aggregatestore/end_to_end_test.go
+++ b/aggregatestore/end_to_end_test.go
@@ -1,0 +1,281 @@
+package aggregatestore_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/go-estoria/estoria"
+	"github.com/go-estoria/estoria/aggregatestore"
+	"github.com/go-estoria/estoria/eventstore/memory"
+	"github.com/go-estoria/estoria/snapshotstore"
+	snapshotmemory "github.com/go-estoria/estoria/snapshotstore/memory"
+	"github.com/go-estoria/estoria/typeid"
+	"github.com/gofrs/uuid/v5"
+)
+
+// This test pins the observable behavior of the full aggregate store composition
+// (EventSourcedStore → SnapshottingStore → CachedStore → HookableStore) so that
+// refactors of the aggregatestore package are measured against it. Only mechanical
+// renames may touch this file while such a refactor is in flight.
+
+type account struct {
+	ID      typeid.ID
+	Balance int
+}
+
+func newAccount(id uuid.UUID) account {
+	return account{ID: typeid.New("account", id)}
+}
+
+type fundsDeposited struct {
+	Amount int
+}
+
+func (fundsDeposited) EventType() string { return "fundsdeposited" }
+
+func (fundsDeposited) New() estoria.DomainEvent[account] { return &fundsDeposited{} }
+
+func (e fundsDeposited) ApplyTo(_ context.Context, a account) (account, error) {
+	a.Balance += e.Amount
+	return a, nil
+}
+
+type fundsWithdrawn struct {
+	Amount int
+}
+
+func (fundsWithdrawn) EventType() string { return "fundswithdrawn" }
+
+func (fundsWithdrawn) New() estoria.DomainEvent[account] { return &fundsWithdrawn{} }
+
+func (e fundsWithdrawn) ApplyTo(_ context.Context, a account) (account, error) {
+	a.Balance -= e.Amount
+	return a, nil
+}
+
+// mapAggregateCache stores entries the way the contrib caches do: state and version,
+// keyed by typed ID. Identity must survive the round trip through the cache.
+type mapAggregateCache[S any] struct {
+	mu      sync.RWMutex
+	entries map[string]aggregatestore.CachedAggregate[S]
+}
+
+func newMapAggregateCache[S any]() *mapAggregateCache[S] {
+	return &mapAggregateCache[S]{entries: make(map[string]aggregatestore.CachedAggregate[S])}
+}
+
+func (c *mapAggregateCache[S]) GetAggregate(_ context.Context, aggregateID typeid.ID) (*aggregatestore.CachedAggregate[S], error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	entry, ok := c.entries[aggregateID.String()]
+	if !ok {
+		return nil, nil //nolint:nilnil // a nil entry with a nil error is the cache-miss contract
+	}
+
+	return &entry, nil
+}
+
+func (c *mapAggregateCache[S]) PutAggregate(_ context.Context, aggregateID typeid.ID, entry aggregatestore.CachedAggregate[S]) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.entries[aggregateID.String()] = entry
+
+	return nil
+}
+
+var _ aggregatestore.AggregateCache[account] = (*mapAggregateCache[account])(nil)
+
+// hookCounts records which lifecycle hooks fired so the test can assert the
+// composition actually routed operations through the hookable layer.
+type hookCounts struct {
+	beforeLoad, afterLoad, beforeSave, afterSave int
+}
+
+func newComposedStore(
+	t *testing.T,
+	eventStore *memory.EventStore,
+	snapshotStore *snapshotmemory.SnapshotStore,
+	cache aggregatestore.AggregateCache[account],
+	counts *hookCounts,
+) *aggregatestore.HookableStore[account] {
+	t.Helper()
+
+	eventSourced, err := aggregatestore.New(eventStore, "account", newAccount,
+		aggregatestore.WithEventTypes[account](fundsDeposited{}, fundsWithdrawn{}))
+	if err != nil {
+		t.Fatalf("creating event sourced store: %v", err)
+	}
+
+	snapshotting, err := aggregatestore.NewSnapshottingStore[account](eventSourced, snapshotStore,
+		snapshotstore.EventCountSnapshotPolicy{N: 3})
+	if err != nil {
+		t.Fatalf("creating snapshotting store: %v", err)
+	}
+
+	cached, err := aggregatestore.NewCachedStore(snapshotting, cache)
+	if err != nil {
+		t.Fatalf("creating cached store: %v", err)
+	}
+
+	hookable, err := aggregatestore.NewHookableStore[account](cached)
+	if err != nil {
+		t.Fatalf("creating hookable store: %v", err)
+	}
+
+	hookable.BeforeLoad(func(_ context.Context, _ uuid.UUID) error {
+		counts.beforeLoad++
+		return nil
+	})
+	hookable.AfterLoad(func(_ context.Context, _ *aggregatestore.Aggregate[account]) error {
+		counts.afterLoad++
+		return nil
+	})
+	hookable.BeforeSave(func(_ context.Context, _ *aggregatestore.Aggregate[account]) error {
+		counts.beforeSave++
+		return nil
+	})
+	hookable.AfterSave(func(_ context.Context, _ *aggregatestore.Aggregate[account]) error {
+		counts.afterSave++
+		return nil
+	})
+
+	return hookable
+}
+
+func TestEndToEnd_FullComposition(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	eventStore, err := memory.NewEventStore()
+	if err != nil {
+		t.Fatalf("creating event store: %v", err)
+	}
+
+	snapshotStore := snapshotmemory.NewSnapshotStore()
+	cache := newMapAggregateCache[account]()
+	counts := &hookCounts{}
+	store := newComposedStore(t, eventStore, snapshotStore, cache, counts)
+
+	accountUUID := uuid.Must(uuid.NewV4())
+	wantID := typeid.New("account", accountUUID)
+
+	// Create an aggregate, append events across two saves, and verify state.
+	// The second save crosses version 3, where the snapshot policy fires.
+	aggregate := store.New(accountUUID)
+	if got := aggregate.ID(); got.String() != wantID.String() {
+		t.Fatalf("new aggregate ID: want %s, got %s", wantID, got)
+	}
+
+	aggregate.Append(fundsDeposited{Amount: 100}, fundsDeposited{Amount: 50})
+
+	if err := store.Save(ctx, aggregate, nil); err != nil {
+		t.Fatalf("saving aggregate: %v", err)
+	}
+
+	if got := aggregate.Version(); got != 2 {
+		t.Fatalf("version after first save: want 2, got %d", got)
+	}
+
+	aggregate.Append(fundsWithdrawn{Amount: 30}, fundsDeposited{Amount: 10}, fundsDeposited{Amount: 5})
+
+	if err := store.Save(ctx, aggregate, nil); err != nil {
+		t.Fatalf("saving aggregate: %v", err)
+	}
+
+	if got := aggregate.Version(); got != 5 {
+		t.Fatalf("version after second save: want 5, got %d", got)
+	}
+
+	if got := aggregate.State().Balance; got != 135 {
+		t.Fatalf("balance after second save: want 135, got %d", got)
+	}
+
+	// The snapshot policy fired at version 3.
+	snap, err := snapshotStore.ReadSnapshot(ctx, wantID, snapshotstore.ReadSnapshotOptions{})
+	if err != nil {
+		t.Fatalf("reading snapshot: %v", err)
+	}
+
+	if snap.AggregateVersion != 3 {
+		t.Errorf("snapshot version: want 3, got %d", snap.AggregateVersion)
+	}
+
+	// A load through the full stack hits the cache; the rebuilt aggregate must
+	// preserve identity, version, and state.
+	loaded, err := store.Load(ctx, accountUUID, nil)
+	if err != nil {
+		t.Fatalf("loading aggregate: %v", err)
+	}
+
+	if got := loaded.ID(); got.String() != wantID.String() {
+		t.Errorf("cached load ID: want %s, got %s", wantID, got)
+	}
+
+	if got := loaded.Version(); got != 5 {
+		t.Errorf("cached load version: want 5, got %d", got)
+	}
+
+	if got := loaded.State().Balance; got != 135 {
+		t.Errorf("cached load balance: want 135, got %d", got)
+	}
+
+	// A load with a cold cache hydrates from the snapshot plus the events past
+	// it and must converge on the same state.
+	coldCounts := &hookCounts{}
+	coldStore := newComposedStore(t, eventStore, snapshotStore, newMapAggregateCache[account](), coldCounts)
+
+	reloaded, err := coldStore.Load(ctx, accountUUID, nil)
+	if err != nil {
+		t.Fatalf("loading aggregate with cold cache: %v", err)
+	}
+
+	if got := reloaded.ID(); got.String() != wantID.String() {
+		t.Errorf("cold load ID: want %s, got %s", wantID, got)
+	}
+
+	if got := reloaded.Version(); got != 5 {
+		t.Errorf("cold load version: want 5, got %d", got)
+	}
+
+	if got := reloaded.State().Balance; got != 135 {
+		t.Errorf("cold load balance: want 135, got %d", got)
+	}
+
+	// Time travel bypasses cache and snapshot (none exists at or below version
+	// 2) and replays events from the beginning.
+	timeTraveled, err := store.Load(ctx, accountUUID, &aggregatestore.LoadOptions{ToVersion: 2})
+	if err != nil {
+		t.Fatalf("loading aggregate to version 2: %v", err)
+	}
+
+	if got := timeTraveled.Version(); got != 2 {
+		t.Errorf("time-traveled version: want 2, got %d", got)
+	}
+
+	if got := timeTraveled.State().Balance; got != 150 {
+		t.Errorf("time-traveled balance: want 150, got %d", got)
+	}
+
+	// Loading an unknown aggregate reports ErrAggregateNotFound through every layer.
+	if _, err := store.Load(ctx, uuid.Must(uuid.NewV4()), nil); !errors.Is(err, aggregatestore.ErrAggregateNotFound) {
+		t.Errorf("loading unknown aggregate: want ErrAggregateNotFound, got %v", err)
+	}
+
+	// Every operation above went through the hookable layer.
+	if counts.beforeSave != 2 || counts.afterSave != 2 {
+		t.Errorf("save hooks: want 2/2, got %d/%d", counts.beforeSave, counts.afterSave)
+	}
+
+	if counts.beforeLoad != 3 || counts.afterLoad != 2 {
+		t.Errorf("load hooks: want before=3 (cache hit, time travel, not-found), after=2 (successes only), got %d/%d", counts.beforeLoad, counts.afterLoad)
+	}
+
+	if coldCounts.beforeLoad != 1 || coldCounts.afterLoad != 1 {
+		t.Errorf("cold store load hooks: want 1/1, got %d/%d", coldCounts.beforeLoad, coldCounts.afterLoad)
+	}
+}

--- a/aggregatestore/event_sourced_store.go
+++ b/aggregatestore/event_sourced_store.go
@@ -5,41 +5,59 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/go-estoria/estoria"
 	"github.com/go-estoria/estoria/eventstore"
 	"github.com/go-estoria/estoria/eventstore/projection"
+	"github.com/go-estoria/estoria/typeid"
 	"github.com/gofrs/uuid/v5"
 )
 
 // An EventSourcedStore loads and saves aggregates using an EventStore.
 // It loads and hydrates aggregates by reading events from the event store and applying
 // them to the aggregate. It saves aggregates by appending events to the event store.
-type EventSourcedStore[E estoria.Entity] struct {
+type EventSourcedStore[S any] struct {
 	eventReader eventstore.StreamReader
 	eventWriter eventstore.StreamWriter
 
-	newEntity             estoria.EntityFactory[E]
-	entityEventPrototypes map[string]func() estoria.EntityEvent[E]
-	entityEventMarshaler  estoria.EntityEventMarshaler[E]
+	aggregateType         string
+	newState              estoria.StateFactory[S]
+	domainEventPrototypes map[string]func() estoria.DomainEvent[S]
+	domainEventCodec      estoria.DomainEventCodec[S]
 
 	log estoria.Logger
 }
 
-var _ Store[estoria.Entity] = (*EventSourcedStore[estoria.Entity])(nil)
+var _ Store[struct{}] = (*EventSourcedStore[struct{}])(nil)
 
 // New creates a new event sourced aggregate store.
-func New[E estoria.Entity](
+//
+// The aggregate type names the kind of aggregate the store manages and becomes the
+// type component of every aggregate ID the store composes. It addresses streams in
+// storage, so it must remain stable for the lifetime of the aggregates it names.
+func New[S any](
 	eventStore eventstore.Store,
-	entityFactory estoria.EntityFactory[E],
-	opts ...EventSourcedStoreOption[E],
-) (*EventSourcedStore[E], error) {
-	store := &EventSourcedStore[E]{
+	aggregateType string,
+	stateFactory estoria.StateFactory[S],
+	opts ...EventSourcedStoreOption[S],
+) (*EventSourcedStore[S], error) {
+	switch {
+	case aggregateType == "":
+		return nil, InitializeError{Err: errors.New("aggregate type is required")}
+	case strings.Contains(aggregateType, "_"):
+		// An underscore separates the type from the UUID in the "type_uuid" string
+		// form, so a type containing one produces ambiguous IDs.
+		return nil, InitializeError{Err: errors.New("aggregate type must not contain '_'")}
+	}
+
+	store := &EventSourcedStore[S]{
 		eventReader:           eventStore,
 		eventWriter:           eventStore,
-		newEntity:             entityFactory,
-		entityEventPrototypes: make(map[string]func() estoria.EntityEvent[E]),
-		entityEventMarshaler:  estoria.JSONEntityEventMarshaler[E]{},
+		aggregateType:         aggregateType,
+		newState:              stateFactory,
+		domainEventPrototypes: make(map[string]func() estoria.DomainEvent[S]),
+		domainEventCodec:      estoria.JSONDomainEventCodec[S]{},
 		log:                   estoria.GetLogger().WithGroup("eventsourcedstore"),
 	}
 
@@ -56,13 +74,19 @@ func New[E estoria.Entity](
 	return store, nil
 }
 
+// AggregateType returns the aggregate type name used to compose the typed IDs
+// under which the store's aggregates are addressed.
+func (s *EventSourcedStore[S]) AggregateType() string {
+	return s.aggregateType
+}
+
 // New creates a new aggregate with the given ID.
-func (s *EventSourcedStore[E]) New(id uuid.UUID) *Aggregate[E] {
-	return NewAggregate(s.newEntity(id), 0)
+func (s *EventSourcedStore[S]) New(id uuid.UUID) *Aggregate[S] {
+	return newAggregate(typeid.New(s.aggregateType, id), s.newState(id), 0)
 }
 
 // Load loads an aggregate by its ID.
-func (s *EventSourcedStore[E]) Load(ctx context.Context, id uuid.UUID, opts *LoadOptions) (*Aggregate[E], error) {
+func (s *EventSourcedStore[S]) Load(ctx context.Context, id uuid.UUID, opts *LoadOptions) (*Aggregate[S], error) {
 	if id == uuid.Nil {
 		return nil, LoadError{Err: errors.New("aggregate ID is nil")}
 	} else if opts == nil {
@@ -89,7 +113,7 @@ func (s *EventSourcedStore[E]) Load(ctx context.Context, id uuid.UUID, opts *Loa
 }
 
 // Hydrate hydrates an aggregate by reading and applying events from the event store.
-func (s *EventSourcedStore[E]) Hydrate(ctx context.Context, aggregate *Aggregate[E], opts *HydrateOptions) error {
+func (s *EventSourcedStore[S]) Hydrate(ctx context.Context, aggregate *Aggregate[S], opts *HydrateOptions) error {
 	if opts == nil {
 		opts = &HydrateOptions{}
 	}
@@ -177,14 +201,14 @@ func (s *EventSourcedStore[E]) Hydrate(ctx context.Context, aggregate *Aggregate
 }
 
 // Save saves an aggregate by appending its unsaved events to the event store.
-func (s *EventSourcedStore[E]) Save(ctx context.Context, aggregate *Aggregate[E], opts *SaveOptions) error {
+func (s *EventSourcedStore[S]) Save(ctx context.Context, aggregate *Aggregate[S], opts *SaveOptions) error {
 	if aggregate == nil {
 		return SaveError{Err: ErrNilAggregate}
 	} else if s.eventWriter == nil {
 		return SaveError{AggregateID: aggregate.ID(), Err: errors.New("event store has no event stream writer")}
 	}
 
-	unsavedEvents := aggregate.state.UnsavedEvents()
+	unsavedEvents := aggregate.unsavedEvents
 	if len(unsavedEvents) == 0 {
 		if aggregate.Version() == 0 {
 			return SaveError{AggregateID: aggregate.ID(), Err: errors.New("new aggregate has no events to save")}
@@ -199,7 +223,7 @@ func (s *EventSourcedStore[E]) Save(ctx context.Context, aggregate *Aggregate[E]
 	events := make([]*eventstore.WritableEvent, len(unsavedEvents))
 
 	for i, unsavedEvent := range unsavedEvents {
-		data, err := s.entityEventMarshaler.MarshalEntityEvent(unsavedEvent.EntityEvent)
+		data, err := s.domainEventCodec.MarshalDomainEvent(unsavedEvent.DomainEvent)
 		if err != nil {
 			return SaveError{AggregateID: aggregate.ID(), Operation: "marshaling event data", Err: err}
 		}
@@ -220,10 +244,10 @@ func (s *EventSourcedStore[E]) Save(ctx context.Context, aggregate *Aggregate[E]
 	// queue the events for application
 	for i, unsavedEvent := range unsavedEvents {
 		unsavedEvent.Version = aggregate.Version() + int64(i) + 1
-		aggregate.state.WillApply(unsavedEvent)
+		aggregate.willApply(unsavedEvent)
 	}
 
-	aggregate.state.ClearUnsavedEvents()
+	aggregate.clearUnsavedEvents()
 
 	if opts == nil {
 		opts = &SaveOptions{}
@@ -235,7 +259,7 @@ func (s *EventSourcedStore[E]) Save(ctx context.Context, aggregate *Aggregate[E]
 
 	// apply the events to the aggregate
 	for {
-		if err := aggregate.state.ApplyNext(ctx); errors.Is(err, ErrNoUnappliedEvents) {
+		if err := aggregate.applyNext(ctx); errors.Is(err, ErrNoUnappliedEvents) {
 			return nil
 		} else if err != nil {
 			return SaveError{AggregateID: aggregate.ID(), Operation: "applying aggregate event", Err: err}
@@ -243,37 +267,37 @@ func (s *EventSourcedStore[E]) Save(ctx context.Context, aggregate *Aggregate[E]
 	}
 }
 
-// Use registers entity event prototypes with the store.
+// Use registers domain event prototypes with the store.
 //
 // A prototype's New() method may return either a pointer to the event type or a
 // value of the event type. For value-returning prototypes, Use inspects the
 // returned type once at registration time and wraps New so that subsequent
-// calls allocate an addressable pointer instance; this lets the marshaler
+// calls allocate an addressable pointer instance; this lets the codec
 // unmarshal into the event without per-hydrate reflection.
-func (s *EventSourcedStore[E]) Use(eventPrototypes ...estoria.EntityEvent[E]) error {
+func (s *EventSourcedStore[S]) Use(eventPrototypes ...estoria.DomainEvent[S]) error {
 	for _, prototype := range eventPrototypes {
-		if _, registered := s.entityEventPrototypes[prototype.EventType()]; registered {
+		if _, registered := s.domainEventPrototypes[prototype.EventType()]; registered {
 			return InitializeError{
-				Operation: "registering entity event prototype",
+				Operation: "registering domain event prototype",
 				Err:       errors.New("duplicate event type " + prototype.EventType()),
 			}
 		}
 
-		s.entityEventPrototypes[prototype.EventType()] = pointerConstructor(prototype.New)
+		s.domainEventPrototypes[prototype.EventType()] = pointerConstructor(prototype.New)
 	}
 
 	return nil
 }
 
-// pointerConstructor returns a constructor that always yields an EntityEvent[E]
+// pointerConstructor returns a constructor that always yields a DomainEvent[S]
 // whose dynamic type is a pointer, so json.Unmarshal can write into it. If
 // newFn already returns a pointer, it is used directly with no overhead.
 // Otherwise the underlying type is captured once and each call invokes newFn
 // (preserving any defaults the user set) and copies the result into a fresh
 // addressable instance, returning the pointer.
-func pointerConstructor[E estoria.Entity](newFn func() estoria.EntityEvent[E]) func() estoria.EntityEvent[E] {
+func pointerConstructor[S any](newFn func() estoria.DomainEvent[S]) func() estoria.DomainEvent[S] {
 	sample := newFn()
-	// A nil-returning New() violates the EntityEvent contract, but the
+	// A nil-returning New() violates the DomainEvent contract, but the
 	// hydration path already surfaces this with a clean error. Returning
 	// newFn directly preserves that behavior instead of letting reflect.New(nil)
 	// panic in the value-wrapping closure below.
@@ -286,56 +310,56 @@ func pointerConstructor[E estoria.Entity](newFn func() estoria.EntityEvent[E]) f
 	}
 
 	t := reflect.TypeOf(sample)
-	return func() estoria.EntityEvent[E] {
+	return func() estoria.DomainEvent[S] {
 		ptr := reflect.New(t)
 		ptr.Elem().Set(reflect.ValueOf(newFn()))
-		ev, ok := ptr.Interface().(estoria.EntityEvent[E])
+		ev, ok := ptr.Interface().(estoria.DomainEvent[S])
 		if !ok {
-			// Unreachable: *T satisfies EntityEvent[E] whenever T does (Go's method-set
+			// Unreachable: *T satisfies DomainEvent[S] whenever T does (Go's method-set
 			// rules guarantee *T's method set is a superset of T's), and T satisfies it
 			// by virtue of newFn's return type.
-			panic(fmt.Sprintf("pointerConstructor: *%s does not satisfy EntityEvent[E]", t.Name()))
+			panic(fmt.Sprintf("pointerConstructor: *%s does not satisfy DomainEvent[S]", t.Name()))
 		}
 		return ev
 	}
 }
 
-// Returns a projection.EventHandlerFunc that decodes and applies an entity event to an aggregate.
-func (s *EventSourcedStore[E]) eventHandlerForAggregate(aggregate *Aggregate[E]) projection.EventHandlerFunc {
+// Returns a projection.EventHandlerFunc that decodes and applies a domain event to an aggregate.
+func (s *EventSourcedStore[S]) eventHandlerForAggregate(aggregate *Aggregate[S]) projection.EventHandlerFunc {
 	return projection.EventHandlerFunc(func(ctx context.Context, event *eventstore.Event) error {
 		if event == nil {
 			return NewHydrateError(aggregate.ID(), "event handler", errors.New("received nil event in event handler"))
 		}
 
 		eventType := event.ID.Type
-		newEvent, ok := s.entityEventPrototypes[eventType]
+		newEvent, ok := s.domainEventPrototypes[eventType]
 		if !ok || newEvent == nil {
-			return NewHydrateError(aggregate.ID(), "obtaining entity prototype",
+			return NewHydrateError(aggregate.ID(), "obtaining domain event prototype",
 				fmt.Errorf("no prototype registered for event type '%s'", eventType),
 			)
 		}
 
-		entityEvent := newEvent()
-		if entityEvent == nil {
-			return NewHydrateError(aggregate.ID(), "creating entity event instance",
+		domainEvent := newEvent()
+		if domainEvent == nil {
+			return NewHydrateError(aggregate.ID(), "creating domain event instance",
 				fmt.Errorf("prototype.New() returned nil for event type '%s'", eventType),
 			)
 		}
 
-		if err := s.entityEventMarshaler.UnmarshalEntityEvent(event.Data, entityEvent); err != nil {
+		if err := s.domainEventCodec.UnmarshalDomainEvent(event.Data, domainEvent); err != nil {
 			return NewHydrateError(aggregate.ID(), "unmarshaling event data",
 				fmt.Errorf("failed to unmarshal event data for event type '%s': %w", eventType, err),
 			)
 		}
 
 		// enqueue and apply the event immediately
-		aggregate.state.WillApply(&AggregateEvent[E, estoria.EntityEvent[E]]{
+		aggregate.willApply(&Event[S]{
 			ID:          event.ID,
 			Version:     event.StreamVersion,
 			Timestamp:   event.Timestamp,
-			EntityEvent: entityEvent,
+			DomainEvent: domainEvent,
 		})
-		if err := aggregate.state.ApplyNext(ctx); err != nil {
+		if err := aggregate.applyNext(ctx); err != nil {
 			return NewHydrateError(aggregate.ID(), "applying aggregate event",
 				fmt.Errorf("failed to apply event type '%s': %w", eventType, err),
 			)
@@ -346,35 +370,35 @@ func (s *EventSourcedStore[E]) eventHandlerForAggregate(aggregate *Aggregate[E])
 }
 
 // An EventSourcedStoreOption is a functional option for configuring an EventSourcedStore.
-type EventSourcedStoreOption[E estoria.Entity] func(*EventSourcedStore[E]) error
+type EventSourcedStoreOption[S any] func(*EventSourcedStore[S]) error
 
-// WithEventTypes registers entity event prototypes with the store.
-func WithEventTypes[E estoria.Entity](eventPrototypes ...estoria.EntityEvent[E]) EventSourcedStoreOption[E] {
-	return func(s *EventSourcedStore[E]) error {
+// WithEventTypes registers domain event prototypes with the store.
+func WithEventTypes[S any](eventPrototypes ...estoria.DomainEvent[S]) EventSourcedStoreOption[S] {
+	return func(s *EventSourcedStore[S]) error {
 		return s.Use(eventPrototypes...)
 	}
 }
 
 // WithEventStreamReader sets the event stream reader for the store.
-func WithEventStreamReader[E estoria.Entity](reader eventstore.StreamReader) EventSourcedStoreOption[E] {
-	return func(s *EventSourcedStore[E]) error {
+func WithEventStreamReader[S any](reader eventstore.StreamReader) EventSourcedStoreOption[S] {
+	return func(s *EventSourcedStore[S]) error {
 		s.eventReader = reader
 		return nil
 	}
 }
 
 // WithEventStreamWriter sets the event stream writer for the store.
-func WithEventStreamWriter[E estoria.Entity](writer eventstore.StreamWriter) EventSourcedStoreOption[E] {
-	return func(s *EventSourcedStore[E]) error {
+func WithEventStreamWriter[S any](writer eventstore.StreamWriter) EventSourcedStoreOption[S] {
+	return func(s *EventSourcedStore[S]) error {
 		s.eventWriter = writer
 		return nil
 	}
 }
 
-// WithEntityEventMarshaler sets the entity event marshaler for the store.
-func WithEntityEventMarshaler[E estoria.Entity](marshaler estoria.EntityEventMarshaler[E]) EventSourcedStoreOption[E] {
-	return func(s *EventSourcedStore[E]) error {
-		s.entityEventMarshaler = marshaler
+// WithDomainEventCodec sets the domain event codec for the store.
+func WithDomainEventCodec[S any](codec estoria.DomainEventCodec[S]) EventSourcedStoreOption[S] {
+	return func(s *EventSourcedStore[S]) error {
+		s.domainEventCodec = codec
 		return nil
 	}
 }

--- a/aggregatestore/event_sourced_store_test.go
+++ b/aggregatestore/event_sourced_store_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/gofrs/uuid/v5"
 )
 
-type eventSourcedStoreTestCase[E estoria.Entity] struct {
+type eventSourcedStoreTestCase[E any] struct {
 	name           string
 	haveEventStore func() eventstore.Store
 	haveOpts       []aggregatestore.EventSourcedStoreOption[E]
@@ -36,7 +36,7 @@ func (e mockEntityEventA) EventType() string {
 	return "mockEntityEventA"
 }
 
-func (e mockEntityEventA) New() estoria.EntityEvent[mockEntity] {
+func (e mockEntityEventA) New() estoria.DomainEvent[mockEntity] {
 	return &mockEntityEventA{}
 }
 
@@ -62,7 +62,7 @@ func (e mockEntityEventB) EventType() string {
 	return "mockEntityEventB"
 }
 
-func (e mockEntityEventB) New() estoria.EntityEvent[mockEntity] {
+func (e mockEntityEventB) New() estoria.DomainEvent[mockEntity] {
 	return &mockEntityEventB{}
 }
 
@@ -88,7 +88,7 @@ func (e mockEntityEventC) EventType() string {
 	return "mockEntityEventC"
 }
 
-func (e mockEntityEventC) New() estoria.EntityEvent[mockEntity] {
+func (e mockEntityEventC) New() estoria.DomainEvent[mockEntity] {
 	return &mockEntityEventC{}
 }
 
@@ -114,7 +114,7 @@ func (e mockEntityEventD) EventType() string {
 	return "mockEntityEventD"
 }
 
-func (e mockEntityEventD) New() estoria.EntityEvent[mockEntity] {
+func (e mockEntityEventD) New() estoria.DomainEvent[mockEntity] {
 	return &mockEntityEventD{}
 }
 
@@ -140,7 +140,7 @@ func (e mockEntityEventE) EventType() string {
 	return "mockEntityEventE"
 }
 
-func (e mockEntityEventE) New() estoria.EntityEvent[mockEntity] {
+func (e mockEntityEventE) New() estoria.DomainEvent[mockEntity] {
 	return &mockEntityEventE{}
 }
 
@@ -166,7 +166,7 @@ func (e mockEntityEventF) EventType() string {
 	return "mockEntityEventF"
 }
 
-func (e mockEntityEventF) New() estoria.EntityEvent[mockEntity] {
+func (e mockEntityEventF) New() estoria.DomainEvent[mockEntity] {
 	return &mockEntityEventF{}
 }
 
@@ -185,7 +185,7 @@ func (e mockEntityValueEvent) EventType() string {
 	return "mockEntityValueEvent"
 }
 
-func (e mockEntityValueEvent) New() estoria.EntityEvent[mockEntity] {
+func (e mockEntityValueEvent) New() estoria.DomainEvent[mockEntity] {
 	return mockEntityValueEvent{}
 }
 
@@ -205,7 +205,7 @@ func (e mockEntityNilNewEvent) EventType() string {
 	return "mockEntityNilNewEvent"
 }
 
-func (e mockEntityNilNewEvent) New() estoria.EntityEvent[mockEntity] {
+func (e mockEntityNilNewEvent) New() estoria.DomainEvent[mockEntity] {
 	return nil
 }
 
@@ -225,7 +225,7 @@ func (e mockEntityValueEventWithDefault) EventType() string {
 	return "mockEntityValueEventWithDefault"
 }
 
-func (e mockEntityValueEventWithDefault) New() estoria.EntityEvent[mockEntity] {
+func (e mockEntityValueEventWithDefault) New() estoria.DomainEvent[mockEntity] {
 	return mockEntityValueEventWithDefault{Default: "seeded"}
 }
 
@@ -268,17 +268,17 @@ func (m mockStreamIterator) Close(_ context.Context) error {
 	return m.closeErr
 }
 
-type mockEventMarshaler[E estoria.Entity] struct {
+type mockEventMarshaler[E any] struct {
 	marshaledBytes []byte
 	marshalErr     error
 	unmarshalErr   error
 }
 
-func (m mockEventMarshaler[E]) MarshalEntityEvent(_ estoria.EntityEvent[E]) ([]byte, error) {
+func (m mockEventMarshaler[E]) MarshalDomainEvent(_ estoria.DomainEvent[E]) ([]byte, error) {
 	return m.marshaledBytes, m.marshalErr
 }
 
-func (m mockEventMarshaler[E]) UnmarshalEntityEvent(_ []byte, _ estoria.EntityEvent[E]) error {
+func (m mockEventMarshaler[E]) UnmarshalDomainEvent(_ []byte, _ estoria.DomainEvent[E]) error {
 	return m.unmarshalErr
 }
 
@@ -348,7 +348,7 @@ func TestNewEventSourcedStore(t *testing.T) {
 				),
 			},
 			wantErr: fmt.Errorf("applying option: %w", aggregatestore.InitializeError{
-				Operation: "registering entity event prototype",
+				Operation: "registering domain event prototype",
 				Err:       errors.New("duplicate event type mockEntityEventA"),
 			}),
 		},
@@ -372,7 +372,7 @@ func TestNewEventSourcedStore(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			gotStore, err := aggregatestore.New(tt.haveEventStore(), newMockEntity, tt.haveOpts...)
+			gotStore, err := aggregatestore.New(tt.haveEventStore(), "mockentity", newMockEntity, tt.haveOpts...)
 
 			if tt.wantErr != nil {
 				if err == nil || err.Error() != tt.wantErr.Error() {
@@ -410,7 +410,7 @@ func TestEventSourcedStore_LoadAggregate(t *testing.T) {
 			haveAggregateID: aggregateID,
 			haveEventStore: func() eventstore.Store {
 				events := []*eventstore.WritableEvent{}
-				for _, event := range []estoria.EntityEvent[mockEntity]{
+				for _, event := range []estoria.DomainEvent[mockEntity]{
 					mockEntityEventA{A: "a"},
 					mockEntityEventB{B: "b"},
 					mockEntityEventC{C: "c"},
@@ -442,7 +442,7 @@ func TestEventSourcedStore_LoadAggregate(t *testing.T) {
 			haveAggregateID: aggregateID,
 			haveEventStore: func() eventstore.Store {
 				events := []*eventstore.WritableEvent{}
-				for _, event := range []estoria.EntityEvent[mockEntity]{
+				for _, event := range []estoria.DomainEvent[mockEntity]{
 					mockEntityEventA{A: "a"},
 					mockEntityEventB{B: "b"},
 					mockEntityEventC{C: "c"},
@@ -492,7 +492,7 @@ func TestEventSourcedStore_LoadAggregate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			store, err := aggregatestore.New(tt.haveEventStore(), newMockEntity, tt.haveStoreOpts...)
+			store, err := aggregatestore.New(tt.haveEventStore(), "mockentity", newMockEntity, tt.haveStoreOpts...)
 			if err != nil {
 				t.Errorf("unexpected error creating store: %v", err)
 			}
@@ -521,7 +521,7 @@ func TestEventSourcedStore_LoadAggregate(t *testing.T) {
 				t.Errorf("want aggregate version %d, got %d", tt.wantVersion, gotAggregate.Version())
 			}
 			// aggregate has the correct entity
-			gotEntity := gotAggregate.Entity()
+			gotEntity := gotAggregate.State()
 			// entity has the correct ID
 			if gotEntity.ID.String() != tt.haveAggregateID.String() {
 				t.Errorf("want entity ID %s, got %s", tt.haveAggregateID, gotEntity.ID)
@@ -552,7 +552,7 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 			name: "hydrates an aggregate from version 0 to the latest version using default options",
 			haveEventStore: func() eventstore.Store {
 				events := []*eventstore.WritableEvent{}
-				for _, event := range []estoria.EntityEvent[mockEntity]{
+				for _, event := range []estoria.DomainEvent[mockEntity]{
 					mockEntityEventA{A: "a"},
 					mockEntityEventB{B: "b"},
 					mockEntityEventC{C: "c"},
@@ -578,7 +578,7 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 				),
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 0)
+				return newMockAggregate(aggregateID.UUID, 0)
 			},
 			haveHydrateOpts: nil,
 			wantVersion:     5,
@@ -591,7 +591,7 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 			name: "hydrates an aggregate from version 0 to a specific version",
 			haveEventStore: func() eventstore.Store {
 				events := []*eventstore.WritableEvent{}
-				for _, event := range []estoria.EntityEvent[mockEntity]{
+				for _, event := range []estoria.DomainEvent[mockEntity]{
 					mockEntityEventA{A: "a"},
 					mockEntityEventB{B: "b"},
 					mockEntityEventC{C: "c"},
@@ -617,7 +617,7 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 				),
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 0)
+				return newMockAggregate(aggregateID.UUID, 0)
 			},
 			haveHydrateOpts: &aggregatestore.HydrateOptions{ToVersion: 3},
 			wantVersion:     3,
@@ -630,7 +630,7 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 			name: "hydrates an aggregate from version 0 to version 1",
 			haveEventStore: func() eventstore.Store {
 				events := []*eventstore.WritableEvent{}
-				for _, event := range []estoria.EntityEvent[mockEntity]{
+				for _, event := range []estoria.DomainEvent[mockEntity]{
 					mockEntityEventA{A: "a"},
 					mockEntityEventB{B: "b"},
 					mockEntityEventC{C: "c"},
@@ -656,7 +656,7 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 				),
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 0)
+				return newMockAggregate(aggregateID.UUID, 0)
 			},
 			haveHydrateOpts: &aggregatestore.HydrateOptions{ToVersion: 1},
 			wantVersion:     1,
@@ -669,7 +669,7 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 			name: "hydrates an aggregate from version 0 to version N-1",
 			haveEventStore: func() eventstore.Store {
 				events := []*eventstore.WritableEvent{}
-				for _, event := range []estoria.EntityEvent[mockEntity]{
+				for _, event := range []estoria.DomainEvent[mockEntity]{
 					mockEntityEventA{A: "a"},
 					mockEntityEventB{B: "b"},
 					mockEntityEventC{C: "c"},
@@ -695,7 +695,7 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 				),
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 0)
+				return newMockAggregate(aggregateID.UUID, 0)
 			},
 			haveHydrateOpts: &aggregatestore.HydrateOptions{ToVersion: 4},
 			wantVersion:     4,
@@ -708,7 +708,7 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 			name: "hydrates an aggregate from version 1 to the latest version using default options",
 			haveEventStore: func() eventstore.Store {
 				events := []*eventstore.WritableEvent{}
-				for _, event := range []estoria.EntityEvent[mockEntity]{
+				for _, event := range []estoria.DomainEvent[mockEntity]{
 					mockEntityEventA{A: "a"},
 					mockEntityEventB{B: "b"},
 					mockEntityEventC{C: "c"},
@@ -734,7 +734,7 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 				),
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 1)
+				return newMockAggregate(aggregateID.UUID, 1)
 			},
 			haveHydrateOpts: nil,
 			wantVersion:     5,
@@ -747,7 +747,7 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 			name: "hydrates an aggregate from version 1 to a specific version",
 			haveEventStore: func() eventstore.Store {
 				events := []*eventstore.WritableEvent{}
-				for _, event := range []estoria.EntityEvent[mockEntity]{
+				for _, event := range []estoria.DomainEvent[mockEntity]{
 					mockEntityEventA{A: "a"},
 					mockEntityEventB{B: "b"},
 					mockEntityEventC{C: "c"},
@@ -773,7 +773,7 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 				),
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 1)
+				return newMockAggregate(aggregateID.UUID, 1)
 			},
 			haveHydrateOpts: &aggregatestore.HydrateOptions{ToVersion: 3},
 			wantVersion:     3,
@@ -786,7 +786,7 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 			name: "hydrates an aggregate from version 1 to version 2",
 			haveEventStore: func() eventstore.Store {
 				events := []*eventstore.WritableEvent{}
-				for _, event := range []estoria.EntityEvent[mockEntity]{
+				for _, event := range []estoria.DomainEvent[mockEntity]{
 					mockEntityEventA{A: "a"},
 					mockEntityEventB{B: "b"},
 					mockEntityEventC{C: "c"},
@@ -812,7 +812,7 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 				),
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 1)
+				return newMockAggregate(aggregateID.UUID, 1)
 			},
 			haveHydrateOpts: &aggregatestore.HydrateOptions{ToVersion: 2},
 			wantVersion:     2,
@@ -825,7 +825,7 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 			name: "hydrates an aggregate from version 1 to version N-1",
 			haveEventStore: func() eventstore.Store {
 				events := []*eventstore.WritableEvent{}
-				for _, event := range []estoria.EntityEvent[mockEntity]{
+				for _, event := range []estoria.DomainEvent[mockEntity]{
 					mockEntityEventA{A: "a"},
 					mockEntityEventB{B: "b"},
 					mockEntityEventC{C: "c"},
@@ -851,7 +851,7 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 				),
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 1)
+				return newMockAggregate(aggregateID.UUID, 1)
 			},
 			haveHydrateOpts: &aggregatestore.HydrateOptions{ToVersion: 4},
 			wantVersion:     4,
@@ -864,7 +864,7 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 			name: "hydrates an aggregate from a specific version to the latest version using default options",
 			haveEventStore: func() eventstore.Store {
 				events := []*eventstore.WritableEvent{}
-				for _, event := range []estoria.EntityEvent[mockEntity]{
+				for _, event := range []estoria.DomainEvent[mockEntity]{
 					mockEntityEventA{A: "a"},
 					mockEntityEventB{B: "b"},
 					mockEntityEventC{C: "c"},
@@ -890,7 +890,7 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 				),
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 3)
+				return newMockAggregate(aggregateID.UUID, 3)
 			},
 			haveHydrateOpts: nil,
 			wantVersion:     5,
@@ -903,7 +903,7 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 			name: "hydrates an aggregate from a specific version to another specific version",
 			haveEventStore: func() eventstore.Store {
 				events := []*eventstore.WritableEvent{}
-				for _, event := range []estoria.EntityEvent[mockEntity]{
+				for _, event := range []estoria.DomainEvent[mockEntity]{
 					mockEntityEventA{A: "a"},
 					mockEntityEventB{B: "b"},
 					mockEntityEventC{C: "c"},
@@ -929,7 +929,7 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 				),
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 3)
+				return newMockAggregate(aggregateID.UUID, 3)
 			},
 			haveHydrateOpts: &aggregatestore.HydrateOptions{ToVersion: 4},
 			wantVersion:     4,
@@ -942,7 +942,7 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 			name: "hydrates an aggregate from a specific version to version N+1",
 			haveEventStore: func() eventstore.Store {
 				events := []*eventstore.WritableEvent{}
-				for _, event := range []estoria.EntityEvent[mockEntity]{
+				for _, event := range []estoria.DomainEvent[mockEntity]{
 					mockEntityEventA{A: "a"},
 					mockEntityEventB{B: "b"},
 					mockEntityEventC{C: "c"},
@@ -968,7 +968,7 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 				),
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 3)
+				return newMockAggregate(aggregateID.UUID, 3)
 			},
 			haveHydrateOpts: &aggregatestore.HydrateOptions{ToVersion: 4},
 			wantVersion:     4,
@@ -981,7 +981,7 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 			name: "hydrates an aggregate from version N-1 to the latest version using default options",
 			haveEventStore: func() eventstore.Store {
 				events := []*eventstore.WritableEvent{}
-				for _, event := range []estoria.EntityEvent[mockEntity]{
+				for _, event := range []estoria.DomainEvent[mockEntity]{
 					mockEntityEventA{A: "a"},
 					mockEntityEventB{B: "b"},
 					mockEntityEventC{C: "c"},
@@ -1007,7 +1007,7 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 				),
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 4)
+				return newMockAggregate(aggregateID.UUID, 4)
 			},
 			haveHydrateOpts: nil,
 			wantVersion:     5,
@@ -1020,7 +1020,7 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 			name: "is a no-op when the aggregate is already at the target version",
 			haveEventStore: func() eventstore.Store {
 				events := []*eventstore.WritableEvent{}
-				for _, event := range []estoria.EntityEvent[mockEntity]{
+				for _, event := range []estoria.DomainEvent[mockEntity]{
 					mockEntityEventA{A: "a"},
 					mockEntityEventB{B: "b"},
 					mockEntityEventC{C: "c"},
@@ -1046,7 +1046,7 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 				),
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 5)
+				return newMockAggregate(aggregateID.UUID, 5)
 			},
 			haveHydrateOpts: &aggregatestore.HydrateOptions{ToVersion: 5},
 			wantVersion:     5,
@@ -1059,7 +1059,7 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 			name: "returns an error when the event stream reader is nil",
 			haveEventStore: func() eventstore.Store {
 				events := []*eventstore.WritableEvent{}
-				for _, event := range []estoria.EntityEvent[mockEntity]{
+				for _, event := range []estoria.DomainEvent[mockEntity]{
 					mockEntityEventA{A: "a"},
 					mockEntityEventB{B: "b"},
 					mockEntityEventC{C: "c"},
@@ -1079,7 +1079,7 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 				aggregatestore.WithEventStreamReader[mockEntity](nil),
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 0)
+				return newMockAggregate(aggregateID.UUID, 0)
 			},
 			haveHydrateOpts: nil,
 			wantErr:         errors.New("event store has no event stream reader"),
@@ -1103,7 +1103,7 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 				return store
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 5)
+				return newMockAggregate(aggregateID.UUID, 5)
 			},
 			haveHydrateOpts: &aggregatestore.HydrateOptions{ToVersion: -1},
 			wantErr:         errors.New("invalid hydrate options: ToVersion cannot be negative"),
@@ -1115,7 +1115,7 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 				return store
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 5)
+				return newMockAggregate(aggregateID.UUID, 5)
 			},
 			haveHydrateOpts: &aggregatestore.HydrateOptions{ToVersion: 3},
 			wantErr:         errors.New("aggregate is at more recent version (5) than requested version (3)"),
@@ -1127,7 +1127,7 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 				return store
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 0)
+				return newMockAggregate(aggregateID.UUID, 0)
 			},
 			wantErr: errors.New("aggregate not found"),
 		},
@@ -1145,7 +1145,7 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 				}),
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 10)
+				return newMockAggregate(aggregateID.UUID, 10)
 			},
 			wantVersion: 10,
 			wantEntity: mockEntity{
@@ -1166,7 +1166,7 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 				}),
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 10)
+				return newMockAggregate(aggregateID.UUID, 10)
 			},
 			haveHydrateOpts: &aggregatestore.HydrateOptions{ToVersion: 15},
 			wantVersion:     10,
@@ -1178,7 +1178,7 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 			name: "returns an error when unable to obtain an event stream iterator",
 			haveEventStore: func() eventstore.Store {
 				events := []*eventstore.WritableEvent{}
-				for _, event := range []estoria.EntityEvent[mockEntity]{
+				for _, event := range []estoria.DomainEvent[mockEntity]{
 					mockEntityEventA{A: "a"},
 					mockEntityEventB{B: "b"},
 					mockEntityEventC{C: "c"},
@@ -1200,7 +1200,7 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 				}),
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 0)
+				return newMockAggregate(aggregateID.UUID, 0)
 			},
 			haveHydrateOpts: nil,
 			wantErr:         errors.New("reading event stream: mock error"),
@@ -1209,7 +1209,7 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 			name: "returns an error when unable to read an event from the event stream",
 			haveEventStore: func() eventstore.Store {
 				events := []*eventstore.WritableEvent{}
-				for _, event := range []estoria.EntityEvent[mockEntity]{
+				for _, event := range []estoria.DomainEvent[mockEntity]{
 					mockEntityEventA{A: "a"},
 					mockEntityEventB{B: "b"},
 					mockEntityEventC{C: "c"},
@@ -1233,7 +1233,7 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 				}),
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 0)
+				return newMockAggregate(aggregateID.UUID, 0)
 			},
 			wantErr: errors.New("projecting event stream: reading event: mock error"),
 		},
@@ -1241,7 +1241,7 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 			name: "returns an error when encountering an unregistered event type",
 			haveEventStore: func() eventstore.Store {
 				events := []*eventstore.WritableEvent{}
-				for _, event := range []estoria.EntityEvent[mockEntity]{
+				for _, event := range []estoria.DomainEvent[mockEntity]{
 					mockEntityEventA{A: "a"},
 				} {
 					events = append(events, &eventstore.WritableEvent{
@@ -1254,15 +1254,15 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 				return store
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 0)
+				return newMockAggregate(aggregateID.UUID, 0)
 			},
-			wantErr: errors.New("projecting event stream: processing event: obtaining entity prototype: no prototype registered for event type 'mockEntityEventA'"),
+			wantErr: errors.New("projecting event stream: processing event: obtaining domain event prototype: no prototype registered for event type 'mockEntityEventA'"),
 		},
 		{
 			name: "returns an error when unable to unmarshal an event store event",
 			haveEventStore: func() eventstore.Store {
 				events := []*eventstore.WritableEvent{}
-				for _, event := range []estoria.EntityEvent[mockEntity]{
+				for _, event := range []estoria.DomainEvent[mockEntity]{
 					mockEntityEventA{A: "a"},
 				} {
 					events = append(events, &eventstore.WritableEvent{
@@ -1275,7 +1275,7 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 				return store
 			},
 			haveStoreOpts: []aggregatestore.EventSourcedStoreOption[mockEntity]{
-				aggregatestore.WithEntityEventMarshaler(
+				aggregatestore.WithDomainEventCodec(
 					mockEventMarshaler[mockEntity]{
 						unmarshalErr: errors.New("mock error"),
 					},
@@ -1285,7 +1285,7 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 				),
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 0)
+				return newMockAggregate(aggregateID.UUID, 0)
 			},
 			wantErr: errors.New("projecting event stream: processing event: unmarshaling event data: failed to unmarshal event data for event type 'mockEntityEventA': mock error"),
 		},
@@ -1293,7 +1293,7 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 			name: "returns an error when unable to apply an event to the aggregate",
 			haveEventStore: func() eventstore.Store {
 				events := []*eventstore.WritableEvent{}
-				for _, event := range []estoria.EntityEvent[mockEntity]{
+				for _, event := range []estoria.DomainEvent[mockEntity]{
 					mockEntityEventA{A: "a"},
 					mockEntityEventB{B: "b"},
 					mockEntityEventC{C: "c"},
@@ -1321,7 +1321,7 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 				),
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 0)
+				return newMockAggregate(aggregateID.UUID, 0)
 			},
 			wantErr: errors.New("projecting event stream: processing event: applying aggregate event: failed to apply event type 'mockEntityEventF': applying event: mock error"),
 		},
@@ -1329,7 +1329,7 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			store, err := aggregatestore.New(tt.haveEventStore(), newMockEntity, tt.haveStoreOpts...)
+			store, err := aggregatestore.New(tt.haveEventStore(), "mockentity", newMockEntity, tt.haveStoreOpts...)
 			if err != nil {
 				t.Errorf("unexpected error creating store: %v", err)
 			}
@@ -1362,7 +1362,7 @@ func TestEventSourcedStore_HydrateAggregate(t *testing.T) {
 				t.Errorf("want aggregate version %d, got %d", tt.wantVersion, aggregate.Version())
 			}
 			// aggregate has a valid entity
-			gotEntity := aggregate.Entity()
+			gotEntity := aggregate.State()
 			// entity has the correct ID
 			if gotEntity.ID.String() != tt.wantEntity.ID.String() {
 				t.Errorf("want entity ID %s, got %s", tt.wantEntity.ID.String(), gotEntity.ID.String())
@@ -1397,7 +1397,7 @@ func TestEventSourcedStore_SaveAggregate(t *testing.T) {
 				return store
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				agg := aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 0)
+				agg := newMockAggregate(aggregateID.UUID, 0)
 				agg.Append(mockEntityEventA{})
 				return agg
 			},
@@ -1414,7 +1414,7 @@ func TestEventSourcedStore_SaveAggregate(t *testing.T) {
 				return store
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				agg := aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 0)
+				agg := newMockAggregate(aggregateID.UUID, 0)
 				agg.Append(
 					mockEntityEventA{},
 					mockEntityEventB{},
@@ -1432,7 +1432,7 @@ func TestEventSourcedStore_SaveAggregate(t *testing.T) {
 			name: "saves an existing aggregate with a single new event using default options",
 			haveEventStore: func() eventstore.Store {
 				events := []*eventstore.WritableEvent{}
-				for _, event := range []estoria.EntityEvent[mockEntity]{
+				for _, event := range []estoria.DomainEvent[mockEntity]{
 					mockEntityEventA{A: "a"},
 					mockEntityEventB{B: "b"},
 					mockEntityEventC{C: "c"},
@@ -1447,7 +1447,7 @@ func TestEventSourcedStore_SaveAggregate(t *testing.T) {
 				return store
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				agg := aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 3)
+				agg := newMockAggregate(aggregateID.UUID, 3)
 				agg.Append(
 					mockEntityEventD{},
 				)
@@ -1463,7 +1463,7 @@ func TestEventSourcedStore_SaveAggregate(t *testing.T) {
 			name: "saves an existing aggregate with multiple new events using default options",
 			haveEventStore: func() eventstore.Store {
 				events := []*eventstore.WritableEvent{}
-				for _, event := range []estoria.EntityEvent[mockEntity]{
+				for _, event := range []estoria.DomainEvent[mockEntity]{
 					mockEntityEventA{A: "a"},
 					mockEntityEventB{B: "b"},
 					mockEntityEventC{C: "c"},
@@ -1478,7 +1478,7 @@ func TestEventSourcedStore_SaveAggregate(t *testing.T) {
 				return store
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				agg := aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 3)
+				agg := newMockAggregate(aggregateID.UUID, 3)
 				agg.Append(
 					mockEntityEventD{},
 					mockEntityEventD{},
@@ -1496,7 +1496,7 @@ func TestEventSourcedStore_SaveAggregate(t *testing.T) {
 			name: "is a no-op when saving an aggregate with no unsaved events",
 			haveEventStore: func() eventstore.Store {
 				events := []*eventstore.WritableEvent{}
-				for _, event := range []estoria.EntityEvent[mockEntity]{
+				for _, event := range []estoria.DomainEvent[mockEntity]{
 					mockEntityEventA{A: "a"},
 					mockEntityEventB{B: "b"},
 					mockEntityEventC{C: "c"},
@@ -1511,7 +1511,7 @@ func TestEventSourcedStore_SaveAggregate(t *testing.T) {
 				return store
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 3)
+				return newMockAggregate(aggregateID.UUID, 3)
 			},
 			wantVersion: 3,
 			wantEntity: mockEntity{
@@ -1523,7 +1523,7 @@ func TestEventSourcedStore_SaveAggregate(t *testing.T) {
 			name: "skips applying events to the aggregate after saving when the SkipApply option is true",
 			haveEventStore: func() eventstore.Store {
 				events := []*eventstore.WritableEvent{}
-				for _, event := range []estoria.EntityEvent[mockEntity]{
+				for _, event := range []estoria.DomainEvent[mockEntity]{
 					mockEntityEventA{A: "a"},
 					mockEntityEventB{B: "b"},
 					mockEntityEventC{C: "c"},
@@ -1538,7 +1538,7 @@ func TestEventSourcedStore_SaveAggregate(t *testing.T) {
 				return store
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				agg := aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 3)
+				agg := newMockAggregate(aggregateID.UUID, 3)
 				agg.Append(
 					mockEntityEventD{},
 					mockEntityEventD{},
@@ -1574,7 +1574,7 @@ func TestEventSourcedStore_SaveAggregate(t *testing.T) {
 				aggregatestore.WithEventStreamWriter[mockEntity](nil),
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 0)
+				return newMockAggregate(aggregateID.UUID, 0)
 			},
 			wantErr: errors.New("event store has no event stream writer"),
 		},
@@ -1585,7 +1585,7 @@ func TestEventSourcedStore_SaveAggregate(t *testing.T) {
 				return store
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 0)
+				return newMockAggregate(aggregateID.UUID, 0)
 			},
 			wantErr: errors.New("new aggregate has no events to save"),
 		},
@@ -1596,14 +1596,14 @@ func TestEventSourcedStore_SaveAggregate(t *testing.T) {
 				return store
 			},
 			haveStoreOpts: []aggregatestore.EventSourcedStoreOption[mockEntity]{
-				aggregatestore.WithEntityEventMarshaler(
+				aggregatestore.WithDomainEventCodec(
 					mockEventMarshaler[mockEntity]{
 						marshalErr: errors.New("mock error"),
 					},
 				),
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				agg := aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 0)
+				agg := newMockAggregate(aggregateID.UUID, 0)
 				agg.Append(
 					mockEntityEventA{},
 				)
@@ -1623,7 +1623,7 @@ func TestEventSourcedStore_SaveAggregate(t *testing.T) {
 				}),
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				agg := aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 0)
+				agg := newMockAggregate(aggregateID.UUID, 0)
 				agg.Append(
 					mockEntityEventA{},
 				)
@@ -1638,7 +1638,7 @@ func TestEventSourcedStore_SaveAggregate(t *testing.T) {
 				return store
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				agg := aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 0)
+				agg := newMockAggregate(aggregateID.UUID, 0)
 				agg.Append(
 					mockEntityEventA{
 						A: "a",
@@ -1657,7 +1657,7 @@ func TestEventSourcedStore_SaveAggregate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			store, err := aggregatestore.New(tt.haveEventStore(), newMockEntity, tt.haveStoreOpts...)
+			store, err := aggregatestore.New(tt.haveEventStore(), "mockentity", newMockEntity, tt.haveStoreOpts...)
 			if err != nil {
 				t.Errorf("unexpected error creating store: %v", err)
 			}
@@ -1690,7 +1690,7 @@ func TestEventSourcedStore_SaveAggregate(t *testing.T) {
 				t.Errorf("want aggregate version %d, got %d", tt.wantVersion, aggregate.Version())
 			}
 			// aggregate has a valid entity
-			gotEntity := aggregate.Entity()
+			gotEntity := aggregate.State()
 			// entity has the correct ID
 			if gotEntity.ID.String() != tt.wantEntity.ID.String() {
 				t.Errorf("want entity ID %s, got %s", tt.wantEntity.ID.String(), gotEntity.ID.String())
@@ -1723,7 +1723,7 @@ func TestEventSourcedStore_HydratesValueTypedEvent(t *testing.T) {
 		t.Fatalf("unexpected error appending event: %v", err)
 	}
 
-	store, err := aggregatestore.New(es, newMockEntity,
+	store, err := aggregatestore.New(es, "mockentity", newMockEntity,
 		aggregatestore.WithEventTypes(mockEntityValueEvent{}),
 	)
 	if err != nil {
@@ -1738,10 +1738,10 @@ func TestEventSourcedStore_HydratesValueTypedEvent(t *testing.T) {
 	if got, want := aggregate.Version(), int64(1); got != want {
 		t.Errorf("want version %d, got %d", want, got)
 	}
-	if got, want := aggregate.Entity().numAppliedEvents, int64(1); got != want {
+	if got, want := aggregate.State().numAppliedEvents, int64(1); got != want {
 		t.Errorf("want numAppliedEvents %d, got %d", want, got)
 	}
-	if got, want := aggregate.Entity().lastValueEventValue, "hello"; got != want {
+	if got, want := aggregate.State().lastValueEventValue, "hello"; got != want {
 		t.Errorf("want lastValueEventValue %q, got %q", want, got)
 	}
 }
@@ -1769,7 +1769,7 @@ func TestEventSourcedStore_PreservesValueTypedEventDefaults(t *testing.T) {
 		t.Fatalf("unexpected error appending event: %v", err)
 	}
 
-	store, err := aggregatestore.New(es, newMockEntity,
+	store, err := aggregatestore.New(es, "mockentity", newMockEntity,
 		aggregatestore.WithEventTypes(mockEntityValueEventWithDefault{}),
 	)
 	if err != nil {
@@ -1781,7 +1781,7 @@ func TestEventSourcedStore_PreservesValueTypedEventDefaults(t *testing.T) {
 		t.Fatalf("unexpected error loading aggregate: %v", err)
 	}
 
-	if got, want := aggregate.Entity().lastValueEventValue, "seeded"; got != want {
+	if got, want := aggregate.State().lastValueEventValue, "seeded"; got != want {
 		t.Errorf("default from New() not preserved: want %q, got %q", want, got)
 	}
 }
@@ -1806,7 +1806,7 @@ func TestEventSourcedStore_NilReturningPrototypeIsHandledCleanly(t *testing.T) {
 		t.Fatalf("unexpected error appending event: %v", err)
 	}
 
-	store, err := aggregatestore.New(es, newMockEntity,
+	store, err := aggregatestore.New(es, "mockentity", newMockEntity,
 		aggregatestore.WithEventTypes(mockEntityNilNewEvent{}),
 	)
 	if err != nil {

--- a/aggregatestore/export_test.go
+++ b/aggregatestore/export_test.go
@@ -1,0 +1,23 @@
+package aggregatestore
+
+import "github.com/go-estoria/estoria/typeid"
+
+// Test-only exports. These give external tests access to aggregate internals that the
+// public API reaches only through full store flows, so that store implementations can
+// be unit tested against mock inner stores.
+
+// NewAggregateForTest constructs an aggregate directly, as stores do internally.
+func NewAggregateForTest[S any](id typeid.ID, state S, version int64) *Aggregate[S] {
+	return newAggregate(id, state, version)
+}
+
+// TestOnlyWillApply enqueues an event to be applied, as a store does after persisting it.
+func (a *Aggregate[S]) TestOnlyWillApply(event *Event[S]) {
+	a.willApply(event)
+}
+
+// TestOnlySetStateAtVersion sets the aggregate's state and version, as the snapshotting
+// store does after decoding a snapshot.
+func (a *Aggregate[S]) TestOnlySetStateAtVersion(state S, version int64) {
+	a.setStateAtVersion(state, version)
+}

--- a/aggregatestore/hookable_store.go
+++ b/aggregatestore/hookable_store.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/go-estoria/estoria"
+	"github.com/go-estoria/estoria/typeid"
 	"github.com/gofrs/uuid/v5"
 )
 
@@ -23,69 +24,74 @@ const (
 type PreloadHook func(ctx context.Context, id uuid.UUID) error
 
 // A Hook is a hook that runs at a specific stage in the aggregate store lifecycle.
-type Hook[E estoria.Entity] func(ctx context.Context, aggregate *Aggregate[E]) error
+type Hook[S any] func(ctx context.Context, aggregate *Aggregate[S]) error
 
 // A HookableStore wraps an aggregate store and provides lifecycle hooks for aggregate store operations.
-type HookableStore[E estoria.Entity] struct {
-	inner        Store[E]
+type HookableStore[S any] struct {
+	inner        Store[S]
 	preloadHooks []PreloadHook
-	hooks        map[HookStage][]Hook[E]
+	hooks        map[HookStage][]Hook[S]
 	log          estoria.Logger
 }
 
-var _ Store[estoria.Entity] = (*HookableStore[estoria.Entity])(nil)
+var _ Store[struct{}] = (*HookableStore[struct{}])(nil)
 
 // NewHookableStore creates a new HookableStore.
-func NewHookableStore[E estoria.Entity](inner Store[E]) (*HookableStore[E], error) {
+func NewHookableStore[S any](inner Store[S]) (*HookableStore[S], error) {
 	if inner == nil {
 		return nil, errors.New("inner store is required")
 	}
 
-	return &HookableStore[E]{
+	return &HookableStore[S]{
 		inner: inner,
-		hooks: make(map[HookStage][]Hook[E]),
+		hooks: make(map[HookStage][]Hook[S]),
 		log:   estoria.GetLogger().WithGroup("hookablestore"),
 	}, nil
 }
 
 // BeforeLoad adds a hook that runs before an aggregate is loaded.
-func (s *HookableStore[E]) BeforeLoad(hooks ...PreloadHook) {
+func (s *HookableStore[S]) BeforeLoad(hooks ...PreloadHook) {
 	s.preloadHooks = append(s.preloadHooks, hooks...)
 }
 
 // AfterLoad adds a hook that runs after an aggregate is loaded.
-func (s *HookableStore[E]) AfterLoad(hooks ...Hook[E]) {
+func (s *HookableStore[S]) AfterLoad(hooks ...Hook[S]) {
 	s.hooks[AfterLoad] = append(s.hooks[AfterLoad], hooks...)
 }
 
 // BeforeHydrate adds a hook that runs before an aggregate is hydrated.
-func (s *HookableStore[E]) BeforeHydrate(hooks ...Hook[E]) {
+func (s *HookableStore[S]) BeforeHydrate(hooks ...Hook[S]) {
 	s.hooks[BeforeHydrate] = append(s.hooks[BeforeHydrate], hooks...)
 }
 
 // AfterHydrate adds a hook that runs after an aggregate is hydrated.
-func (s *HookableStore[E]) AfterHydrate(hooks ...Hook[E]) {
+func (s *HookableStore[S]) AfterHydrate(hooks ...Hook[S]) {
 	s.hooks[AfterHydrate] = append(s.hooks[AfterHydrate], hooks...)
 }
 
 // BeforeSave adds a hook that runs before an aggregate is saved.
-func (s *HookableStore[E]) BeforeSave(hooks ...Hook[E]) {
+func (s *HookableStore[S]) BeforeSave(hooks ...Hook[S]) {
 	s.hooks[BeforeSave] = append(s.hooks[BeforeSave], hooks...)
 }
 
 // AfterSave adds a hook that runs after an aggregate is saved.
-func (s *HookableStore[E]) AfterSave(hooks ...Hook[E]) {
+func (s *HookableStore[S]) AfterSave(hooks ...Hook[S]) {
 	s.hooks[AfterSave] = append(s.hooks[AfterSave], hooks...)
 }
 
+// AggregateType returns the aggregate type name of the inner store.
+func (s *HookableStore[S]) AggregateType() string {
+	return s.inner.AggregateType()
+}
+
 // New creates a new aggregate with the given ID.
-func (s *HookableStore[E]) New(id uuid.UUID) *Aggregate[E] {
+func (s *HookableStore[S]) New(id uuid.UUID) *Aggregate[S] {
 	return s.inner.New(id)
 }
 
 // Load loads an aggregate by ID, executing any pre- and post-load hooks.
-func (s *HookableStore[E]) Load(ctx context.Context, id uuid.UUID, opts *LoadOptions) (*Aggregate[E], error) {
-	aggregateID := s.inner.New(id).ID()
+func (s *HookableStore[S]) Load(ctx context.Context, id uuid.UUID, opts *LoadOptions) (*Aggregate[S], error) {
+	aggregateID := typeid.New(s.inner.AggregateType(), id)
 
 	s.log.Debug("loading aggregate", "aggregate_id", aggregateID)
 	for _, hook := range s.preloadHooks {
@@ -109,7 +115,7 @@ func (s *HookableStore[E]) Load(ctx context.Context, id uuid.UUID, opts *LoadOpt
 }
 
 // Hydrate hydrates an aggregate, executing any pre- and post-hydrate hooks.
-func (s *HookableStore[E]) Hydrate(ctx context.Context, aggregate *Aggregate[E], opts *HydrateOptions) error {
+func (s *HookableStore[S]) Hydrate(ctx context.Context, aggregate *Aggregate[S], opts *HydrateOptions) error {
 	if aggregate == nil {
 		return HydrateError{Err: ErrNilAggregate}
 	}
@@ -135,7 +141,7 @@ func (s *HookableStore[E]) Hydrate(ctx context.Context, aggregate *Aggregate[E],
 }
 
 // Save saves an aggregate, executing any pre- and post-save hooks.
-func (s *HookableStore[E]) Save(ctx context.Context, aggregate *Aggregate[E], opts *SaveOptions) error {
+func (s *HookableStore[S]) Save(ctx context.Context, aggregate *Aggregate[S], opts *SaveOptions) error {
 	if aggregate == nil {
 		return SaveError{Err: ErrNilAggregate}
 	}

--- a/aggregatestore/hookable_store_test.go
+++ b/aggregatestore/hookable_store_test.go
@@ -65,27 +65,27 @@ func TestHookableStore_Load(t *testing.T) {
 			name: "loads an aggergate using the inner store when no hooks are provided",
 			haveInner: &mockAggregateStore[mockEntity]{
 				NewFn: func(id uuid.UUID) *aggregatestore.Aggregate[mockEntity] {
-					return aggregatestore.NewAggregate(newMockEntity(id), 0)
+					return newMockAggregate(id, 0)
 				},
 				LoadFn: func(_ context.Context, id uuid.UUID, _ *aggregatestore.LoadOptions) (*aggregatestore.Aggregate[mockEntity], error) {
-					return aggregatestore.NewAggregate(newMockEntity(id), 42), nil
+					return newMockAggregate(id, 42), nil
 				},
 			},
 			havePreloadHooks: []aggregatestore.PreloadHook{},
 			haveHooks:        map[aggregatestore.HookStage][]aggregatestore.Hook[mockEntity]{},
 			haveAggregateID:  aggregateID,
 			wantAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID), 42)
+				return newMockAggregate(aggregateID, 42)
 			}(),
 		},
 		{
 			name: "loads an aggergate using the inner store and runs a single pre-load hook",
 			haveInner: &mockAggregateStore[mockEntity]{
 				NewFn: func(id uuid.UUID) *aggregatestore.Aggregate[mockEntity] {
-					return aggregatestore.NewAggregate(newMockEntity(id), 0)
+					return newMockAggregate(id, 0)
 				},
 				LoadFn: func(_ context.Context, id uuid.UUID, _ *aggregatestore.LoadOptions) (*aggregatestore.Aggregate[mockEntity], error) {
-					return aggregatestore.NewAggregate(newMockEntity(id), 42), nil
+					return newMockAggregate(id, 42), nil
 				},
 			},
 			havePreloadHooks: []aggregatestore.PreloadHook{
@@ -101,10 +101,10 @@ func TestHookableStore_Load(t *testing.T) {
 			name: "loads an aggergate using the inner store and runs multiple pre-load hooks",
 			haveInner: &mockAggregateStore[mockEntity]{
 				NewFn: func(id uuid.UUID) *aggregatestore.Aggregate[mockEntity] {
-					return aggregatestore.NewAggregate(newMockEntity(id), 0)
+					return newMockAggregate(id, 0)
 				},
 				LoadFn: func(_ context.Context, id uuid.UUID, _ *aggregatestore.LoadOptions) (*aggregatestore.Aggregate[mockEntity], error) {
-					return aggregatestore.NewAggregate(newMockEntity(id), 42), nil
+					return newMockAggregate(id, 42), nil
 				},
 			},
 			havePreloadHooks: []aggregatestore.PreloadHook{
@@ -126,10 +126,10 @@ func TestHookableStore_Load(t *testing.T) {
 			name: "loads an aggergate using the inner store and runs a single post-load hook",
 			haveInner: &mockAggregateStore[mockEntity]{
 				NewFn: func(id uuid.UUID) *aggregatestore.Aggregate[mockEntity] {
-					return aggregatestore.NewAggregate(newMockEntity(id), 0)
+					return newMockAggregate(id, 0)
 				},
 				LoadFn: func(_ context.Context, id uuid.UUID, _ *aggregatestore.LoadOptions) (*aggregatestore.Aggregate[mockEntity], error) {
-					return aggregatestore.NewAggregate(newMockEntity(id), 42), nil
+					return newMockAggregate(id, 42), nil
 				},
 			},
 			haveHooks: map[aggregatestore.HookStage][]aggregatestore.Hook[mockEntity]{
@@ -146,10 +146,10 @@ func TestHookableStore_Load(t *testing.T) {
 			name: "loads an aggergate using the inner store and runs multiple post-load hooks",
 			haveInner: &mockAggregateStore[mockEntity]{
 				NewFn: func(id uuid.UUID) *aggregatestore.Aggregate[mockEntity] {
-					return aggregatestore.NewAggregate(newMockEntity(id), 0)
+					return newMockAggregate(id, 0)
 				},
 				LoadFn: func(_ context.Context, id uuid.UUID, _ *aggregatestore.LoadOptions) (*aggregatestore.Aggregate[mockEntity], error) {
-					return aggregatestore.NewAggregate(newMockEntity(id), 42), nil
+					return newMockAggregate(id, 42), nil
 				},
 			},
 			haveHooks: map[aggregatestore.HookStage][]aggregatestore.Hook[mockEntity]{
@@ -172,7 +172,7 @@ func TestHookableStore_Load(t *testing.T) {
 			name: "returns an error when the inner store returns an error",
 			haveInner: &mockAggregateStore[mockEntity]{
 				NewFn: func(id uuid.UUID) *aggregatestore.Aggregate[mockEntity] {
-					return aggregatestore.NewAggregate(newMockEntity(id), 0)
+					return newMockAggregate(id, 0)
 				},
 				LoadFn: func(_ context.Context, _ uuid.UUID, _ *aggregatestore.LoadOptions) (*aggregatestore.Aggregate[mockEntity], error) {
 					return nil, errors.New("mock error")
@@ -240,15 +240,15 @@ func TestHookableStore_Hydrate(t *testing.T) {
 			name: "hydrates an aggregate using the inner store",
 			haveInner: &mockAggregateStore[mockEntity]{
 				HydrateFn: func(_ context.Context, aggregate *aggregatestore.Aggregate[mockEntity], _ *aggregatestore.HydrateOptions) error {
-					aggregate.State().SetEntityAtVersion(newMockEntity(aggregateID), 42)
+					aggregate.TestOnlySetStateAtVersion(newMockEntity(aggregateID), 42)
 					return nil
 				},
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID), 0)
+				return newMockAggregate(aggregateID, 0)
 			}(),
 			wantAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID), 42)
+				return newMockAggregate(aggregateID, 42)
 			}(),
 		},
 	} {
@@ -310,23 +310,23 @@ func TestHookableStore_Save(t *testing.T) {
 			name: "saves an aggregate using the inner store when no hooks are provided",
 			haveInner: &mockAggregateStore[mockEntity]{
 				SaveFn: func(_ context.Context, aggregate *aggregatestore.Aggregate[mockEntity], _ *aggregatestore.SaveOptions) error {
-					aggregate.State().SetEntityAtVersion(newMockEntity(aggregateID), aggregate.Version()+1)
+					aggregate.TestOnlySetStateAtVersion(newMockEntity(aggregateID), aggregate.Version()+1)
 					return nil
 				},
 			},
 			haveHooks: map[aggregatestore.HookStage][]aggregatestore.Hook[mockEntity]{},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID), 42)
+				return newMockAggregate(aggregateID, 42)
 			}(),
 			wantAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID), 43)
+				return newMockAggregate(aggregateID, 43)
 			}(),
 		},
 		{
 			name: "saves an aggregate using the inner store when a single pre-save hook is provided",
 			haveInner: &mockAggregateStore[mockEntity]{
 				SaveFn: func(_ context.Context, aggregate *aggregatestore.Aggregate[mockEntity], _ *aggregatestore.SaveOptions) error {
-					aggregate.State().SetEntityAtVersion(newMockEntity(aggregateID), aggregate.Version()+1)
+					aggregate.TestOnlySetStateAtVersion(newMockEntity(aggregateID), aggregate.Version()+1)
 					return nil
 				},
 			},
@@ -338,7 +338,7 @@ func TestHookableStore_Save(t *testing.T) {
 				},
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID), 42)
+				return newMockAggregate(aggregateID, 42)
 			}(),
 			wantErr: errors.New("pre-save hook: mock error"),
 		},
@@ -346,7 +346,7 @@ func TestHookableStore_Save(t *testing.T) {
 			name: "saves an aggregate using the inner store when multiple pre-save hooks are provided",
 			haveInner: &mockAggregateStore[mockEntity]{
 				SaveFn: func(_ context.Context, aggregate *aggregatestore.Aggregate[mockEntity], _ *aggregatestore.SaveOptions) error {
-					aggregate.State().SetEntityAtVersion(newMockEntity(aggregateID), aggregate.Version()+1)
+					aggregate.TestOnlySetStateAtVersion(newMockEntity(aggregateID), aggregate.Version()+1)
 					return nil
 				},
 			},
@@ -364,7 +364,7 @@ func TestHookableStore_Save(t *testing.T) {
 				},
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID), 42)
+				return newMockAggregate(aggregateID, 42)
 			}(),
 			wantErr: errors.New("pre-save hook: mock error"),
 		},
@@ -372,7 +372,7 @@ func TestHookableStore_Save(t *testing.T) {
 			name: "saves an aggregate using the inner store when a single post-save hook is provided",
 			haveInner: &mockAggregateStore[mockEntity]{
 				SaveFn: func(_ context.Context, aggregate *aggregatestore.Aggregate[mockEntity], _ *aggregatestore.SaveOptions) error {
-					aggregate.State().SetEntityAtVersion(newMockEntity(aggregateID), aggregate.Version()+1)
+					aggregate.TestOnlySetStateAtVersion(newMockEntity(aggregateID), aggregate.Version()+1)
 					return nil
 				},
 			},
@@ -384,7 +384,7 @@ func TestHookableStore_Save(t *testing.T) {
 				},
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID), 42)
+				return newMockAggregate(aggregateID, 42)
 			}(),
 			wantErr: errors.New("post-save hook: mock error"),
 		},
@@ -392,7 +392,7 @@ func TestHookableStore_Save(t *testing.T) {
 			name: "saves an aggregate using the inner store when multiple post-save hooks are provided",
 			haveInner: &mockAggregateStore[mockEntity]{
 				SaveFn: func(_ context.Context, aggregate *aggregatestore.Aggregate[mockEntity], _ *aggregatestore.SaveOptions) error {
-					aggregate.State().SetEntityAtVersion(newMockEntity(aggregateID), aggregate.Version()+1)
+					aggregate.TestOnlySetStateAtVersion(newMockEntity(aggregateID), aggregate.Version()+1)
 					return nil
 				},
 			},
@@ -410,7 +410,7 @@ func TestHookableStore_Save(t *testing.T) {
 				},
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID), 42)
+				return newMockAggregate(aggregateID, 42)
 			}(),
 			wantErr: errors.New("post-save hook: mock error"),
 		},
@@ -422,7 +422,7 @@ func TestHookableStore_Save(t *testing.T) {
 				},
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID), 42)
+				return newMockAggregate(aggregateID, 42)
 			}(),
 			wantErr: errors.New("saving aggregate using inner store: mock error"),
 		},

--- a/aggregatestore/snapshotting_store.go
+++ b/aggregatestore/snapshotting_store.go
@@ -18,24 +18,24 @@ type SnapshotPolicy interface {
 
 // A SnapshottingStore wraps an aggregate store and uses a snapshot store to save snapshots
 // and/or hydrate aggregates from snapshots.
-type SnapshottingStore[E estoria.Entity] struct {
-	inner     Store[E]
-	reader    snapshotstore.SnapshotReader
-	writer    snapshotstore.SnapshotWriter
-	policy    SnapshotPolicy
-	marshaler estoria.EntityMarshaler[E]
-	log       estoria.Logger
+type SnapshottingStore[S any] struct {
+	inner      Store[S]
+	reader     snapshotstore.SnapshotReader
+	writer     snapshotstore.SnapshotWriter
+	policy     SnapshotPolicy
+	stateCodec estoria.StateCodec[S]
+	log        estoria.Logger
 }
 
-var _ Store[estoria.Entity] = (*SnapshottingStore[estoria.Entity])(nil)
+var _ Store[struct{}] = (*SnapshottingStore[struct{}])(nil)
 
 // NewSnapshottingStore creates a new SnapshottingStore.
-func NewSnapshottingStore[E estoria.Entity](
-	inner Store[E],
+func NewSnapshottingStore[S any](
+	inner Store[S],
 	store snapshotstore.SnapshotStore,
 	policy SnapshotPolicy,
-	opts ...SnapshottingStoreOption[E],
-) (*SnapshottingStore[E], error) {
+	opts ...SnapshottingStoreOption[S],
+) (*SnapshottingStore[S], error) {
 	switch {
 	case inner == nil:
 		return nil, InitializeError{Err: errors.New("inner store is required")}
@@ -45,13 +45,13 @@ func NewSnapshottingStore[E estoria.Entity](
 		return nil, InitializeError{Err: errors.New("snapshot policy is required")}
 	}
 
-	aggregateStore := &SnapshottingStore[E]{
-		inner:     inner,
-		reader:    store,
-		writer:    store,
-		policy:    policy,
-		marshaler: estoria.JSONMarshaler[E]{},
-		log:       estoria.GetLogger().WithGroup("snapshottingstore"),
+	aggregateStore := &SnapshottingStore[S]{
+		inner:      inner,
+		reader:     store,
+		writer:     store,
+		policy:     policy,
+		stateCodec: estoria.JSONStateCodec[S]{},
+		log:        estoria.GetLogger().WithGroup("snapshottingstore"),
 	}
 
 	for _, opt := range opts {
@@ -63,13 +63,18 @@ func NewSnapshottingStore[E estoria.Entity](
 	return aggregateStore, nil
 }
 
+// AggregateType returns the aggregate type name of the inner store.
+func (s *SnapshottingStore[S]) AggregateType() string {
+	return s.inner.AggregateType()
+}
+
 // New creates a new aggregate.
-func (s *SnapshottingStore[E]) New(id uuid.UUID) *Aggregate[E] {
+func (s *SnapshottingStore[S]) New(id uuid.UUID) *Aggregate[S] {
 	return s.inner.New(id)
 }
 
 // Load loads an aggregate by its ID.
-func (s *SnapshottingStore[E]) Load(ctx context.Context, id uuid.UUID, opts *LoadOptions) (*Aggregate[E], error) {
+func (s *SnapshottingStore[S]) Load(ctx context.Context, id uuid.UUID, opts *LoadOptions) (*Aggregate[S], error) {
 	aggregate := s.New(id)
 	s.log.Debug("loading aggregate", "aggregate_id", aggregate.ID())
 
@@ -86,7 +91,7 @@ func (s *SnapshottingStore[E]) Load(ctx context.Context, id uuid.UUID, opts *Loa
 }
 
 // Hydrate hydrates an aggregate, first attempting to load from a snapshot.
-func (s *SnapshottingStore[E]) Hydrate(ctx context.Context, aggregate *Aggregate[E], opts *HydrateOptions) error {
+func (s *SnapshottingStore[S]) Hydrate(ctx context.Context, aggregate *Aggregate[S], opts *HydrateOptions) error {
 	if opts == nil {
 		opts = &HydrateOptions{}
 	}
@@ -128,20 +133,20 @@ func (s *SnapshottingStore[E]) Hydrate(ctx context.Context, aggregate *Aggregate
 		return s.inner.Hydrate(ctx, aggregate, opts)
 	}
 
-	// Decode into a fresh entity rather than the aggregate's live one. When E is a
-	// pointer type the marshaler writes through to the entity in place, so a snapshot
+	// Decode into fresh state rather than the aggregate's live state. When S is a
+	// pointer type the codec writes through to the state in place, so a snapshot
 	// that is valid JSON but disagrees on a field's type — ordinary schema drift —
-	// applies the fields it can before failing. Decoding into the live entity would
+	// applies the fields it can before failing. Decoding into the live state would
 	// leave that partial state behind and then replay events on top of it, silently
 	// returning a corrupt aggregate with a nil error.
-	entity := s.inner.New(aggregate.ID().UUID).Entity()
-	if err := s.marshaler.UnmarshalEntity(snap.Data, &entity); err != nil {
+	state := s.inner.New(aggregate.ID().UUID).State()
+	if err := s.stateCodec.UnmarshalState(snap.Data, &state); err != nil {
 		log.Warn("failed to unmarshal snapshot, falling back to full hydration", "error", err)
 		return s.inner.Hydrate(ctx, aggregate, opts)
 	}
 
 	log.Debug("loaded snapshot", "version", snap.AggregateVersion)
-	aggregate.state.SetEntityAtVersion(entity, snap.AggregateVersion)
+	aggregate.setStateAtVersion(state, snap.AggregateVersion)
 
 	if opts.ToVersion > 0 && snap.AggregateVersion == opts.ToVersion {
 		return nil
@@ -151,7 +156,7 @@ func (s *SnapshottingStore[E]) Hydrate(ctx context.Context, aggregate *Aggregate
 }
 
 // Save saves an aggregate, taking snapshots as needed.
-func (s *SnapshottingStore[E]) Save(ctx context.Context, aggregate *Aggregate[E], opts *SaveOptions) error {
+func (s *SnapshottingStore[S]) Save(ctx context.Context, aggregate *Aggregate[S], opts *SaveOptions) error {
 	if aggregate == nil {
 		return SaveError{Err: ErrNilAggregate}
 	}
@@ -177,7 +182,7 @@ func (s *SnapshottingStore[E]) Save(ctx context.Context, aggregate *Aggregate[E]
 	now := time.Now()
 
 	for {
-		err := aggregate.state.ApplyNext(ctx)
+		err := aggregate.applyNext(ctx)
 		if errors.Is(err, ErrNoUnappliedEvents) {
 			break
 		} else if err != nil {
@@ -190,7 +195,7 @@ func (s *SnapshottingStore[E]) Save(ctx context.Context, aggregate *Aggregate[E]
 
 		log.Debug("taking snapshot", "version", aggregate.Version())
 
-		data, err := s.marshaler.MarshalEntity(aggregate.Entity())
+		data, err := s.stateCodec.MarshalState(aggregate.State())
 		if err != nil {
 			log.Error("failed to marshal snapshot", "error", err)
 			continue
@@ -210,27 +215,27 @@ func (s *SnapshottingStore[E]) Save(ctx context.Context, aggregate *Aggregate[E]
 }
 
 // A SnapshottingStoreOption is a functional option for configuring a SnapshottingStore.
-type SnapshottingStoreOption[E estoria.Entity] func(*SnapshottingStore[E]) error
+type SnapshottingStoreOption[S any] func(*SnapshottingStore[S]) error
 
-// WithSnapshotMarshaler sets the snapshot marshaler.
-func WithSnapshotMarshaler[E estoria.Entity](marshaler estoria.EntityMarshaler[E]) SnapshottingStoreOption[E] {
-	return func(s *SnapshottingStore[E]) error {
-		s.marshaler = marshaler
+// WithStateCodec sets the codec used to marshal state into snapshot payloads.
+func WithStateCodec[S any](codec estoria.StateCodec[S]) SnapshottingStoreOption[S] {
+	return func(s *SnapshottingStore[S]) error {
+		s.stateCodec = codec
 		return nil
 	}
 }
 
 // WithSnapshotReader sets the snapshot reader.
-func WithSnapshotReader[E estoria.Entity](reader snapshotstore.SnapshotReader) SnapshottingStoreOption[E] {
-	return func(s *SnapshottingStore[E]) error {
+func WithSnapshotReader[S any](reader snapshotstore.SnapshotReader) SnapshottingStoreOption[S] {
+	return func(s *SnapshottingStore[S]) error {
 		s.reader = reader
 		return nil
 	}
 }
 
 // WithSnapshotWriter sets the snapshot writer.
-func WithSnapshotWriter[E estoria.Entity](writer snapshotstore.SnapshotWriter) SnapshottingStoreOption[E] {
-	return func(s *SnapshottingStore[E]) error {
+func WithSnapshotWriter[S any](writer snapshotstore.SnapshotWriter) SnapshottingStoreOption[S] {
+	return func(s *SnapshottingStore[S]) error {
 		s.writer = writer
 		return nil
 	}

--- a/aggregatestore/snapshotting_store_test.go
+++ b/aggregatestore/snapshotting_store_test.go
@@ -101,7 +101,7 @@ type mockSnapshotMarshaler struct {
 	UnmarshalFn func([]byte, *mockEntity) error
 }
 
-func (m *mockSnapshotMarshaler) MarshalEntity(entity mockEntity) ([]byte, error) {
+func (m *mockSnapshotMarshaler) MarshalState(entity mockEntity) ([]byte, error) {
 	if m.MarshalFn != nil {
 		return m.MarshalFn(entity)
 	}
@@ -109,7 +109,7 @@ func (m *mockSnapshotMarshaler) MarshalEntity(entity mockEntity) ([]byte, error)
 	return nil, errors.New("unexpected call to Marshal")
 }
 
-func (m *mockSnapshotMarshaler) UnmarshalEntity(data []byte, entity *mockEntity) error {
+func (m *mockSnapshotMarshaler) UnmarshalState(data []byte, entity *mockEntity) error {
 	if m.UnmarshalFn != nil {
 		return m.UnmarshalFn(data, entity)
 	}
@@ -140,7 +140,7 @@ func TestNewSnapshottingStore(t *testing.T) {
 			haveSnapshotStore:  &mockSnapshotStore{},
 			haveSnapshotPolicy: &mockSnapshotPolicy{},
 			haveOpts: []aggregatestore.SnapshottingStoreOption[mockEntity]{
-				aggregatestore.WithSnapshotMarshaler(estoria.JSONMarshaler[mockEntity]{}),
+				aggregatestore.WithStateCodec(estoria.JSONStateCodec[mockEntity]{}),
 			},
 		},
 		{
@@ -237,7 +237,7 @@ func TestSnapshottingStore_Load(t *testing.T) {
 			name: "creates a new aggregate and hydrates it using default options",
 			haveInner: &mockAggregateStore[mockEntity]{
 				NewFn: func(id uuid.UUID) *aggregatestore.Aggregate[mockEntity] {
-					return aggregatestore.NewAggregate(newMockEntity(id), 0)
+					return newMockAggregate(id, 0)
 				},
 				HydrateFn: func(_ context.Context, _ *aggregatestore.Aggregate[mockEntity], _ *aggregatestore.HydrateOptions) error {
 					return nil
@@ -254,14 +254,14 @@ func TestSnapshottingStore_Load(t *testing.T) {
 			},
 			haveAggregateID: aggregateID,
 			wantAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID), 12)
+				return newMockAggregate(aggregateID, 12)
 			}(),
 		},
 		{
 			name: "passes the correct ToVersion hydrate option",
 			haveInner: &mockAggregateStore[mockEntity]{
 				NewFn: func(id uuid.UUID) *aggregatestore.Aggregate[mockEntity] {
-					return aggregatestore.NewAggregate(newMockEntity(id), 0)
+					return newMockAggregate(id, 0)
 				},
 				HydrateFn: func(_ context.Context, _ *aggregatestore.Aggregate[mockEntity], opts *aggregatestore.HydrateOptions) error {
 					if opts.ToVersion != 42 {
@@ -285,34 +285,34 @@ func TestSnapshottingStore_Load(t *testing.T) {
 				ToVersion: 42,
 			},
 			wantAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID), 42)
+				return newMockAggregate(aggregateID, 42)
 			}(),
 		},
 		{
 			name: "falls back to hydrating using the inner store when creating the aggregate fails",
 			haveInner: &mockAggregateStore[mockEntity]{
 				NewFn: func(id uuid.UUID) *aggregatestore.Aggregate[mockEntity] {
-					return aggregatestore.NewAggregate(newMockEntity(id), 0)
+					return newMockAggregate(id, 0)
 				},
 				HydrateFn: func(_ context.Context, aggregate *aggregatestore.Aggregate[mockEntity], _ *aggregatestore.HydrateOptions) error {
-					aggregate.State().SetEntityAtVersion(aggregate.Entity(), 42)
+					aggregate.TestOnlySetStateAtVersion(aggregate.State(), 42)
 					return nil
 				},
 			},
 			haveSnapshotStore: &mockSnapshotStore{},
 			haveAggregateID:   aggregateID,
 			wantAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID), 42)
+				return newMockAggregate(aggregateID, 42)
 			}(),
 		},
 		{
 			name: "falls back to hydrating using the inner store when hydrating the aggregate fails",
 			haveInner: &mockAggregateStore[mockEntity]{
 				NewFn: func(id uuid.UUID) *aggregatestore.Aggregate[mockEntity] {
-					return aggregatestore.NewAggregate(newMockEntity(id), 0)
+					return newMockAggregate(id, 0)
 				},
 				HydrateFn: func(_ context.Context, aggregate *aggregatestore.Aggregate[mockEntity], _ *aggregatestore.HydrateOptions) error {
-					aggregate.State().SetEntityAtVersion(aggregate.Entity(), 42)
+					aggregate.TestOnlySetStateAtVersion(aggregate.State(), 42)
 					return nil
 				},
 			},
@@ -326,7 +326,7 @@ func TestSnapshottingStore_Load(t *testing.T) {
 				ToVersion: 42,
 			},
 			wantAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID), 42)
+				return newMockAggregate(aggregateID, 42)
 			}(),
 		},
 	} {
@@ -380,7 +380,7 @@ func TestSnapshottingStore_Hydrate(t *testing.T) {
 	for _, tt := range []struct {
 		name                      string
 		haveInner                 aggregatestore.Store[mockEntity]
-		haveEntityFactory         estoria.EntityFactory[mockEntity]
+		haveEntityFactory         estoria.StateFactory[mockEntity]
 		haveSnapshotStore         snapshotstore.SnapshotStore
 		haveSnapshottingStoreOpts []aggregatestore.SnapshottingStoreOption[mockEntity]
 		haveAggregate             *aggregatestore.Aggregate[mockEntity]
@@ -392,7 +392,7 @@ func TestSnapshottingStore_Hydrate(t *testing.T) {
 			name: "hydrates an aggregate to a snapshot version",
 			haveInner: &mockAggregateStore[mockEntity]{
 				NewFn: func(id uuid.UUID) *aggregatestore.Aggregate[mockEntity] {
-					return aggregatestore.NewAggregate(newMockEntity(id), 0)
+					return newMockAggregate(id, 0)
 				},
 				HydrateFn: func(_ context.Context, _ *aggregatestore.Aggregate[mockEntity], _ *aggregatestore.HydrateOptions) error {
 					return nil
@@ -408,25 +408,23 @@ func TestSnapshottingStore_Hydrate(t *testing.T) {
 				},
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				agg := &aggregatestore.Aggregate[mockEntity]{}
-				agg.State().SetEntityAtVersion(mockEntity{ID: aggregateID}, 0)
-				return agg
+				return newMockAggregate(aggregateID.UUID, 0)
 			}(),
 			haveOpts: &aggregatestore.HydrateOptions{
 				ToVersion: 42,
 			},
 			wantAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 42)
+				return newMockAggregate(aggregateID.UUID, 42)
 			}(),
 		},
 		{
 			name: "hydrates an aggregate to a snapshot version then further hydrates it using the inner store",
 			haveInner: &mockAggregateStore[mockEntity]{
 				NewFn: func(id uuid.UUID) *aggregatestore.Aggregate[mockEntity] {
-					return aggregatestore.NewAggregate(newMockEntity(id), 0)
+					return newMockAggregate(id, 0)
 				},
 				HydrateFn: func(_ context.Context, aggregate *aggregatestore.Aggregate[mockEntity], _ *aggregatestore.HydrateOptions) error {
-					aggregate.State().SetEntityAtVersion(aggregate.Entity(), aggregate.Version()+3)
+					aggregate.TestOnlySetStateAtVersion(aggregate.State(), aggregate.Version()+3)
 					return nil
 				},
 			},
@@ -440,12 +438,10 @@ func TestSnapshottingStore_Hydrate(t *testing.T) {
 				},
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				agg := &aggregatestore.Aggregate[mockEntity]{}
-				agg.State().SetEntityAtVersion(mockEntity{ID: aggregateID}, 0)
-				return agg
+				return newMockAggregate(aggregateID.UUID, 0)
 			}(),
 			wantAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 45)
+				return newMockAggregate(aggregateID.UUID, 45)
 			}(),
 		},
 		// {
@@ -455,7 +451,7 @@ func TestSnapshottingStore_Hydrate(t *testing.T) {
 			name: "falls back to hydrating using the inner store when already at the target version",
 			haveInner: &mockAggregateStore[mockEntity]{
 				NewFn: func(id uuid.UUID) *aggregatestore.Aggregate[mockEntity] {
-					return aggregatestore.NewAggregate(newMockEntity(id), 0)
+					return newMockAggregate(id, 0)
 				},
 				HydrateFn: func(_ context.Context, _ *aggregatestore.Aggregate[mockEntity], _ *aggregatestore.HydrateOptions) error {
 					return nil
@@ -463,20 +459,20 @@ func TestSnapshottingStore_Hydrate(t *testing.T) {
 			},
 			haveSnapshotStore: &mockSnapshotStore{},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 42)
+				return newMockAggregate(aggregateID.UUID, 42)
 			}(),
 			haveOpts: &aggregatestore.HydrateOptions{
 				ToVersion: 42,
 			},
 			wantAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 42)
+				return newMockAggregate(aggregateID.UUID, 42)
 			}(),
 		},
 		{
 			name: "falls back to hydrating using the inner store when target version is less than current version",
 			haveInner: &mockAggregateStore[mockEntity]{
 				NewFn: func(id uuid.UUID) *aggregatestore.Aggregate[mockEntity] {
-					return aggregatestore.NewAggregate(newMockEntity(id), 0)
+					return newMockAggregate(id, 0)
 				},
 				HydrateFn: func(_ context.Context, _ *aggregatestore.Aggregate[mockEntity], _ *aggregatestore.HydrateOptions) error {
 					return nil
@@ -484,23 +480,23 @@ func TestSnapshottingStore_Hydrate(t *testing.T) {
 			},
 			haveSnapshotStore: &mockSnapshotStore{},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 42)
+				return newMockAggregate(aggregateID.UUID, 42)
 			}(),
 			haveOpts: &aggregatestore.HydrateOptions{
 				ToVersion: 37,
 			},
 			wantAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 42)
+				return newMockAggregate(aggregateID.UUID, 42)
 			}(),
 		},
 		{
 			name: "falls back to hydrating using the inner store when reading a snapshot fails",
 			haveInner: &mockAggregateStore[mockEntity]{
 				NewFn: func(id uuid.UUID) *aggregatestore.Aggregate[mockEntity] {
-					return aggregatestore.NewAggregate(newMockEntity(id), 0)
+					return newMockAggregate(id, 0)
 				},
 				HydrateFn: func(_ context.Context, aggregate *aggregatestore.Aggregate[mockEntity], _ *aggregatestore.HydrateOptions) error {
-					aggregate.State().SetEntityAtVersion(aggregate.Entity(), aggregate.Version()+3)
+					aggregate.TestOnlySetStateAtVersion(aggregate.State(), aggregate.Version()+3)
 					return nil
 				},
 			},
@@ -510,20 +506,20 @@ func TestSnapshottingStore_Hydrate(t *testing.T) {
 				},
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 42)
+				return newMockAggregate(aggregateID.UUID, 42)
 			}(),
 			wantAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 45)
+				return newMockAggregate(aggregateID.UUID, 45)
 			}(),
 		},
 		{
 			name: "falls back to hydrating using the inner store when no snapshot is available",
 			haveInner: &mockAggregateStore[mockEntity]{
 				NewFn: func(id uuid.UUID) *aggregatestore.Aggregate[mockEntity] {
-					return aggregatestore.NewAggregate(newMockEntity(id), 0)
+					return newMockAggregate(id, 0)
 				},
 				HydrateFn: func(_ context.Context, aggregate *aggregatestore.Aggregate[mockEntity], _ *aggregatestore.HydrateOptions) error {
-					aggregate.State().SetEntityAtVersion(aggregate.Entity(), aggregate.Version()+3)
+					aggregate.TestOnlySetStateAtVersion(aggregate.State(), aggregate.Version()+3)
 					return nil
 				},
 			},
@@ -533,20 +529,20 @@ func TestSnapshottingStore_Hydrate(t *testing.T) {
 				},
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 42)
+				return newMockAggregate(aggregateID.UUID, 42)
 			}(),
 			wantAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 45)
+				return newMockAggregate(aggregateID.UUID, 45)
 			}(),
 		},
 		{
 			name: "falls back to hydrating using the inner store the snapshot cannot be unmarshaled",
 			haveInner: &mockAggregateStore[mockEntity]{
 				NewFn: func(id uuid.UUID) *aggregatestore.Aggregate[mockEntity] {
-					return aggregatestore.NewAggregate(newMockEntity(id), 0)
+					return newMockAggregate(id, 0)
 				},
 				HydrateFn: func(_ context.Context, aggregate *aggregatestore.Aggregate[mockEntity], _ *aggregatestore.HydrateOptions) error {
-					aggregate.State().SetEntityAtVersion(aggregate.Entity(), aggregate.Version()+3)
+					aggregate.TestOnlySetStateAtVersion(aggregate.State(), aggregate.Version()+3)
 					return nil
 				},
 			},
@@ -560,13 +556,13 @@ func TestSnapshottingStore_Hydrate(t *testing.T) {
 				},
 			},
 			haveSnapshottingStoreOpts: []aggregatestore.SnapshottingStoreOption[mockEntity]{
-				aggregatestore.WithSnapshotMarshaler(estoria.JSONMarshaler[mockEntity]{}),
+				aggregatestore.WithStateCodec(estoria.JSONStateCodec[mockEntity]{}),
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 42)
+				return newMockAggregate(aggregateID.UUID, 42)
 			}(),
 			wantAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 45)
+				return newMockAggregate(aggregateID.UUID, 45)
 			}(),
 		},
 		{
@@ -581,7 +577,7 @@ func TestSnapshottingStore_Hydrate(t *testing.T) {
 			haveInner:         &mockAggregateStore[mockEntity]{},
 			haveSnapshotStore: &mockSnapshotStore{},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 42)
+				return newMockAggregate(aggregateID.UUID, 42)
 			}(),
 			haveOpts: &aggregatestore.HydrateOptions{
 				ToVersion: -1,
@@ -596,7 +592,7 @@ func TestSnapshottingStore_Hydrate(t *testing.T) {
 				aggregatestore.WithSnapshotReader[mockEntity](nil),
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 42)
+				return newMockAggregate(aggregateID.UUID, 42)
 			}(),
 			wantErr: aggregatestore.HydrateError{Err: errors.New("snapshot store has no snapshot reader")},
 		},
@@ -664,9 +660,9 @@ func TestSnapshottingStore_Save(t *testing.T) {
 			name: "saves an aggregate using the inner store and creates no snapshot if the policy does not require it",
 			haveInner: &mockAggregateStore[mockEntity]{
 				SaveFn: func(_ context.Context, aggregate *aggregatestore.Aggregate[mockEntity], _ *aggregatestore.SaveOptions) error {
-					aggregate.State().WillApply(&aggregatestore.AggregateEvent[mockEntity, estoria.EntityEvent[mockEntity]]{
+					aggregate.TestOnlyWillApply(&aggregatestore.Event[mockEntity]{
 						Version:     43,
-						EntityEvent: mockEntityEventA{},
+						DomainEvent: mockEntityEventA{},
 					})
 					return nil
 				},
@@ -678,21 +674,19 @@ func TestSnapshottingStore_Save(t *testing.T) {
 				},
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 42)
+				return newMockAggregate(aggregateID.UUID, 42)
 			}(),
 			wantAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				agg := &aggregatestore.Aggregate[mockEntity]{}
-				agg.State().SetEntityAtVersion(mockEntity{ID: aggregateID}, 43)
-				return agg
+				return newMockAggregate(aggregateID.UUID, 43)
 			}(),
 		},
 		{
 			name: "saves an aggregate using the inner store and creates no snapshot if the snapshot fails to marshal",
 			haveInner: &mockAggregateStore[mockEntity]{
 				SaveFn: func(_ context.Context, aggregate *aggregatestore.Aggregate[mockEntity], _ *aggregatestore.SaveOptions) error {
-					aggregate.State().WillApply(&aggregatestore.AggregateEvent[mockEntity, estoria.EntityEvent[mockEntity]]{
+					aggregate.TestOnlyWillApply(&aggregatestore.Event[mockEntity]{
 						Version:     43,
-						EntityEvent: mockEntityEventA{},
+						DomainEvent: mockEntityEventA{},
 					})
 					return nil
 				},
@@ -704,28 +698,26 @@ func TestSnapshottingStore_Save(t *testing.T) {
 				},
 			},
 			haveSnapshottingStoreOpts: []aggregatestore.SnapshottingStoreOption[mockEntity]{
-				aggregatestore.WithSnapshotMarshaler(&mockSnapshotMarshaler{
+				aggregatestore.WithStateCodec(&mockSnapshotMarshaler{
 					MarshalFn: func(_ mockEntity) ([]byte, error) {
 						return nil, errors.New("mock error")
 					},
 				}),
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 42)
+				return newMockAggregate(aggregateID.UUID, 42)
 			}(),
 			wantAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				agg := &aggregatestore.Aggregate[mockEntity]{}
-				agg.State().SetEntityAtVersion(mockEntity{ID: aggregateID}, 43)
-				return agg
+				return newMockAggregate(aggregateID.UUID, 43)
 			}(),
 		},
 		{
 			name: "saves an aggregate using the inner store and creates no snapshot if the snapshot writer fails to write",
 			haveInner: &mockAggregateStore[mockEntity]{
 				SaveFn: func(_ context.Context, aggregate *aggregatestore.Aggregate[mockEntity], _ *aggregatestore.SaveOptions) error {
-					aggregate.State().WillApply(&aggregatestore.AggregateEvent[mockEntity, estoria.EntityEvent[mockEntity]]{
+					aggregate.TestOnlyWillApply(&aggregatestore.Event[mockEntity]{
 						Version:     43,
-						EntityEvent: mockEntityEventA{},
+						DomainEvent: mockEntityEventA{},
 					})
 					return nil
 				},
@@ -741,21 +733,19 @@ func TestSnapshottingStore_Save(t *testing.T) {
 				},
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 42)
+				return newMockAggregate(aggregateID.UUID, 42)
 			}(),
 			wantAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				agg := &aggregatestore.Aggregate[mockEntity]{}
-				agg.State().SetEntityAtVersion(mockEntity{ID: aggregateID}, 43)
-				return agg
+				return newMockAggregate(aggregateID.UUID, 43)
 			}(),
 		},
 		{
 			name: "saves an aggregate using the inner store and creates a snapshot if the policy requires it",
 			haveInner: &mockAggregateStore[mockEntity]{
 				SaveFn: func(_ context.Context, aggregate *aggregatestore.Aggregate[mockEntity], _ *aggregatestore.SaveOptions) error {
-					aggregate.State().WillApply(&aggregatestore.AggregateEvent[mockEntity, estoria.EntityEvent[mockEntity]]{
+					aggregate.TestOnlyWillApply(&aggregatestore.Event[mockEntity]{
 						Version:     43,
-						EntityEvent: mockEntityEventA{},
+						DomainEvent: mockEntityEventA{},
 					})
 					return nil
 				},
@@ -771,12 +761,10 @@ func TestSnapshottingStore_Save(t *testing.T) {
 				},
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 42)
+				return newMockAggregate(aggregateID.UUID, 42)
 			}(),
 			wantAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				agg := &aggregatestore.Aggregate[mockEntity]{}
-				agg.State().SetEntityAtVersion(mockEntity{ID: aggregateID}, 43)
-				return agg
+				return newMockAggregate(aggregateID.UUID, 43)
 			}(),
 		},
 		{
@@ -797,7 +785,7 @@ func TestSnapshottingStore_Save(t *testing.T) {
 			haveSnapshotStore:  &mockSnapshotStore{},
 			haveSnapshotPolicy: &mockSnapshotPolicy{},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 42)
+				return newMockAggregate(aggregateID.UUID, 42)
 			}(),
 			wantErr: aggregatestore.SaveError{Err: errors.New("saving aggregate using inner store: mock error")},
 		},
@@ -805,9 +793,9 @@ func TestSnapshottingStore_Save(t *testing.T) {
 			name: "returns an error when encountering an unexpected error applying an event",
 			haveInner: &mockAggregateStore[mockEntity]{
 				SaveFn: func(_ context.Context, aggregate *aggregatestore.Aggregate[mockEntity], _ *aggregatestore.SaveOptions) error {
-					aggregate.State().WillApply(&aggregatestore.AggregateEvent[mockEntity, estoria.EntityEvent[mockEntity]]{
+					aggregate.TestOnlyWillApply(&aggregatestore.Event[mockEntity]{
 						Version: 43,
-						EntityEvent: mockEntityEventA{
+						DomainEvent: mockEntityEventA{
 							mockEntityEventBase: mockEntityEventBase{
 								ApplyToFn: func(_ context.Context, e mockEntity) (mockEntity, error) {
 									return e, errors.New("mock error")
@@ -829,7 +817,7 @@ func TestSnapshottingStore_Save(t *testing.T) {
 				},
 			},
 			haveAggregate: func() *aggregatestore.Aggregate[mockEntity] {
-				return aggregatestore.NewAggregate(newMockEntity(aggregateID.UUID), 42)
+				return newMockAggregate(aggregateID.UUID, 42)
 			}(),
 			wantErr: aggregatestore.SaveError{Err: errors.New("applying next aggregate event: applying event: mock error")},
 		},
@@ -897,7 +885,7 @@ func TestSnapshottingStore_LoadsAggregateSnapshottedAtStreamTip(t *testing.T) {
 
 	wrappedEventStore := &emptyFilteredReadIsNotFoundStore{Store: eventStore}
 
-	inner, err := aggregatestore.New(wrappedEventStore, newMockEntity,
+	inner, err := aggregatestore.New(wrappedEventStore, "mockentity", newMockEntity,
 		aggregatestore.WithEventTypes(mockEntityEventA{}),
 	)
 	if err != nil {
@@ -928,7 +916,7 @@ func TestSnapshottingStore_LoadsAggregateSnapshottedAtStreamTip(t *testing.T) {
 		},
 		// round-trips the entity state that JSON cannot see, so that a load from a snapshot
 		// is distinguishable from a full replay of the stream
-		aggregatestore.WithSnapshotMarshaler[mockEntity](&mockSnapshotMarshaler{
+		aggregatestore.WithStateCodec[mockEntity](&mockSnapshotMarshaler{
 			MarshalFn: func(entity mockEntity) ([]byte, error) {
 				return []byte(strconv.FormatInt(entity.numAppliedEvents, 10)), nil
 			},
@@ -952,9 +940,8 @@ func TestSnapshottingStore_LoadsAggregateSnapshottedAtStreamTip(t *testing.T) {
 	// save one event at a time, loading after each save, so the aggregate is read back at
 	// every version -- including the versions where a snapshot lands on the stream tip
 	for version := int64(1); version <= 2*snapshotEvery; version++ {
-		if err := aggregate.Append(mockEntityEventA{A: "a"}); err != nil {
-			t.Fatalf("unexpected error appending event at version %d: %v", version, err)
-		} else if err := store.Save(ctx, aggregate, nil); err != nil {
+		aggregate.Append(mockEntityEventA{A: "a"})
+		if err := store.Save(ctx, aggregate, nil); err != nil {
 			t.Fatalf("unexpected error saving aggregate at version %d: %v", version, err)
 		}
 
@@ -967,7 +954,7 @@ func TestSnapshottingStore_LoadsAggregateSnapshottedAtStreamTip(t *testing.T) {
 			t.Errorf("want aggregate version %d, got %d", version, loaded.Version())
 		}
 
-		if got := loaded.Entity().numAppliedEvents; got != version {
+		if got := loaded.State().numAppliedEvents; got != version {
 			t.Errorf("want %d applied events at version %d, got %d", version, version, got)
 		}
 	}
@@ -992,8 +979,6 @@ type mockPointerEntity struct {
 	Owner string `json:"owner"`
 }
 
-var _ estoria.Entity = (*mockPointerEntity)(nil)
-
 func newMockPointerEntity(id uuid.UUID) *mockPointerEntity {
 	return &mockPointerEntity{ID: typeid.New("mockpointerentity", id)}
 }
@@ -1006,7 +991,7 @@ type mockPointerEntityEvent struct {
 
 func (e *mockPointerEntityEvent) EventType() string { return "credited" }
 
-func (e *mockPointerEntityEvent) New() estoria.EntityEvent[*mockPointerEntity] {
+func (e *mockPointerEntityEvent) New() estoria.DomainEvent[*mockPointerEntity] {
 	return &mockPointerEntityEvent{}
 }
 
@@ -1027,7 +1012,7 @@ func TestSnapshottingStore_Save_DoesNotMutateCallerOptions(t *testing.T) {
 		t.Fatalf("creating event store: %v", err)
 	}
 
-	inner, err := aggregatestore.New[mockEntity](eventStore, newMockEntity,
+	inner, err := aggregatestore.New[mockEntity](eventStore, "mockentity", newMockEntity,
 		aggregatestore.WithEventTypes[mockEntity](&mockEntityEventA{}))
 	if err != nil {
 		t.Fatalf("creating inner store: %v", err)
@@ -1047,9 +1032,7 @@ func TestSnapshottingStore_Save_DoesNotMutateCallerOptions(t *testing.T) {
 	opts := &aggregatestore.SaveOptions{}
 
 	first := snapshotting.New(uuid.Must(uuid.NewV4()))
-	if err := first.Append(&mockEntityEventA{}); err != nil {
-		t.Fatalf("appending event: %v", err)
-	}
+	first.Append(&mockEntityEventA{})
 	if err := snapshotting.Save(t.Context(), first, opts); err != nil {
 		t.Fatalf("saving through snapshotting store: %v", err)
 	}
@@ -1060,9 +1043,7 @@ func TestSnapshottingStore_Save_DoesNotMutateCallerOptions(t *testing.T) {
 
 	// Reusing the same options on another store must still apply events.
 	second := inner.New(uuid.Must(uuid.NewV4()))
-	if err := second.Append(&mockEntityEventA{}); err != nil {
-		t.Fatalf("appending event: %v", err)
-	}
+	second.Append(&mockEntityEventA{})
 	if err := inner.Save(t.Context(), second, opts); err != nil {
 		t.Fatalf("saving through inner store: %v", err)
 	}
@@ -1072,9 +1053,7 @@ func TestSnapshottingStore_Save_DoesNotMutateCallerOptions(t *testing.T) {
 	}
 
 	// The stale version is what produced the spurious conflict, so save once more.
-	if err := second.Append(&mockEntityEventA{}); err != nil {
-		t.Fatalf("appending event: %v", err)
-	}
+	second.Append(&mockEntityEventA{})
 	if err := inner.Save(t.Context(), second, &aggregatestore.SaveOptions{}); err != nil {
 		t.Errorf("unexpected error on subsequent save: %v", err)
 	}
@@ -1096,7 +1075,7 @@ func TestSnapshottingStore_Hydrate_PartialSnapshotDoesNotCorruptEntity(t *testin
 		t.Fatalf("creating event store: %v", err)
 	}
 
-	inner, err := aggregatestore.New[*mockPointerEntity](eventStore, newMockPointerEntity,
+	inner, err := aggregatestore.New[*mockPointerEntity](eventStore, "mockpointerentity", newMockPointerEntity,
 		aggregatestore.WithEventTypes[*mockPointerEntity](&mockPointerEntityEvent{}))
 	if err != nil {
 		t.Fatalf("creating inner store: %v", err)
@@ -1106,9 +1085,7 @@ func TestSnapshottingStore_Hydrate_PartialSnapshotDoesNotCorruptEntity(t *testin
 	id := uuid.Must(uuid.NewV4())
 	seed := inner.New(id)
 	for range 3 {
-		if err := seed.Append(&mockPointerEntityEvent{Amount: 1}); err != nil {
-			t.Fatalf("appending event: %v", err)
-		}
+		seed.Append(&mockPointerEntityEvent{Amount: 1})
 	}
 	if err := inner.Save(t.Context(), seed, nil); err != nil {
 		t.Fatalf("seeding stream: %v", err)
@@ -1140,10 +1117,10 @@ func TestSnapshottingStore_Hydrate_PartialSnapshotDoesNotCorruptEntity(t *testin
 	if want := int64(3); got.Version() != want {
 		t.Errorf("want version %d, got %d", want, got.Version())
 	}
-	if want := 3; got.Entity().Balance != want {
-		t.Errorf("want balance %d, got %d", want, got.Entity().Balance)
+	if want := 3; got.State().Balance != want {
+		t.Errorf("want balance %d, got %d", want, got.State().Balance)
 	}
-	if owner := got.Entity().Owner; owner != "" {
+	if owner := got.State().Owner; owner != "" {
 		t.Errorf("state leaked from a failed snapshot unmarshal: want empty owner, got %q", owner)
 	}
 }

--- a/entity.go
+++ b/entity.go
@@ -4,66 +4,71 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/go-estoria/estoria/typeid"
 	"github.com/gofrs/uuid/v5"
 )
 
-// An Entity is anything whose state can be constructed by applying a series of events.
-type Entity interface {
-	// EntityID returns the entity's typed identifier.
-	EntityID() typeid.ID
+// Entity constrained aggregate state to types that could report their own typed ID.
+// estoria no longer requires that: the aggregate carries its identity, and the store
+// composes it from the aggregate type name and the UUID it is given.
+//
+// Deprecated: Entity is an alias for any so that existing constraints keep compiling.
+// It will be removed in v0.8.0; use a plain [S any] constraint instead.
+type Entity = any
+
+// A StateFactory creates a new instance of an aggregate's state type S.
+// The UUID identifies the aggregate the state belongs to; the state may record it,
+// but is not required to.
+type StateFactory[S any] func(id uuid.UUID) S
+
+// StateCodec is an interface for marshaling aggregate state to and from bytes.
+type StateCodec[S any] interface {
+	// MarshalState marshals state to bytes.
+	MarshalState(state S) ([]byte, error)
+	// UnmarshalState unmarshals state from bytes.
+	UnmarshalState(data []byte, dest *S) error
 }
 
-// An EntityFactory is a function that creates a new instance of an entity of type E.
-type EntityFactory[E Entity] func(id uuid.UUID) E
+// JSONStateCodec is a StateCodec that encodes state as JSON.
+type JSONStateCodec[S any] struct{}
 
-// EntityMarshaler is an interface for marshaling entities to and from a type T.
-type EntityMarshaler[E Entity] interface {
-	// MarshalEntity marshals an entity to a type T.
-	MarshalEntity(entity E) ([]byte, error)
-	// UnmarshalEntity unmarshals an entity from a type T.
-	UnmarshalEntity(data []byte, dest *E) error
+var _ StateCodec[struct{}] = JSONStateCodec[struct{}]{}
+
+func (c JSONStateCodec[S]) MarshalState(state S) ([]byte, error) {
+	return json.Marshal(state)
 }
 
-type JSONMarshaler[E Entity] struct{}
-
-var _ EntityMarshaler[Entity] = JSONMarshaler[Entity]{}
-
-func (m JSONMarshaler[E]) MarshalEntity(entity E) ([]byte, error) {
-	b, err := json.Marshal(entity)
-	return b, err
-}
-
-func (m JSONMarshaler[E]) UnmarshalEntity(data []byte, dest *E) error {
+func (c JSONStateCodec[S]) UnmarshalState(data []byte, dest *S) error {
 	return json.Unmarshal(data, &dest)
 }
 
-// EntityEvent is an event that can be applied to an entity to change its state.
-type EntityEvent[E Entity] interface {
+// A DomainEvent is an event that can be applied to an aggregate's state to produce
+// the next state.
+type DomainEvent[S any] interface {
 	// EventType returns the type of event.
 	EventType() string
 	// New returns a new instance of the event.
-	New() EntityEvent[E]
-	// ApplyTo applies the event to an entity, returning the new entity state.
-	ApplyTo(ctx context.Context, entity E) (E, error)
+	New() DomainEvent[S]
+	// ApplyTo applies the event to state, returning the new state.
+	ApplyTo(ctx context.Context, state S) (S, error)
 }
 
-// EntityEventMarshaler is an interface for marshaling entity events to and from a type T.
-type EntityEventMarshaler[E Entity] interface {
-	// MarshalEntityEvent marshals an entity event to a type T.
-	MarshalEntityEvent(event EntityEvent[E]) ([]byte, error)
-	// UnmarshalEntityEvent unmarshals an entity event from a type T.
-	UnmarshalEntityEvent(data []byte, dest EntityEvent[E]) error
+// DomainEventCodec is an interface for marshaling domain events to and from bytes.
+type DomainEventCodec[S any] interface {
+	// MarshalDomainEvent marshals a domain event to bytes.
+	MarshalDomainEvent(event DomainEvent[S]) ([]byte, error)
+	// UnmarshalDomainEvent unmarshals a domain event from bytes.
+	UnmarshalDomainEvent(data []byte, dest DomainEvent[S]) error
 }
 
-type JSONEntityEventMarshaler[E Entity] struct{}
+// JSONDomainEventCodec is a DomainEventCodec that encodes domain events as JSON.
+type JSONDomainEventCodec[S any] struct{}
 
-var _ EntityEventMarshaler[Entity] = JSONEntityEventMarshaler[Entity]{}
+var _ DomainEventCodec[struct{}] = JSONDomainEventCodec[struct{}]{}
 
-func (m JSONEntityEventMarshaler[E]) MarshalEntityEvent(event EntityEvent[E]) ([]byte, error) {
+func (c JSONDomainEventCodec[S]) MarshalDomainEvent(event DomainEvent[S]) ([]byte, error) {
 	return json.Marshal(event)
 }
 
-func (m JSONEntityEventMarshaler[E]) UnmarshalEntityEvent(data []byte, dest EntityEvent[E]) error {
+func (c JSONDomainEventCodec[S]) UnmarshalDomainEvent(data []byte, dest DomainEvent[S]) error {
 	return json.Unmarshal(data, dest)
 }

--- a/entity_test.go
+++ b/entity_test.go
@@ -5,48 +5,39 @@ import (
 	"testing"
 
 	"github.com/go-estoria/estoria"
-	"github.com/go-estoria/estoria/typeid"
 	"github.com/gofrs/uuid/v5"
 )
 
-// mockEntity is value-typed, the shape every entity double in this repo used before the
+// mockState is value-typed, the shape every state double in this repo used before the
 // snapshot-corruption fix.
-type mockEntity struct {
+type mockState struct {
 	ID      uuid.UUID `json:"id"`
 	Owner   string    `json:"owner"`
 	Balance int64     `json:"balance"`
 }
 
-func (e mockEntity) EntityID() typeid.ID {
-	return typeid.New("mockentity", e.ID)
-}
-
-// mockPointerEntity is pointer-typed. Marshaling writes through it in place, which is the
+// mockPointerState is pointer-typed. Marshaling writes through it in place, which is the
 // property that made a failed snapshot decode corrupt live state.
-type mockPointerEntity struct {
+type mockPointerState struct {
 	ID      uuid.UUID `json:"id"`
 	Owner   string    `json:"owner"`
 	Balance int64     `json:"balance"`
 }
 
-func (e *mockPointerEntity) EntityID() typeid.ID {
-	return typeid.New("mockpointerentity", e.ID)
-}
-
-func TestJSONMarshaler_ValueEntity(t *testing.T) {
+func TestJSONStateCodec_ValueState(t *testing.T) {
 	t.Parallel()
 
-	marshaler := estoria.JSONMarshaler[mockEntity]{}
-	want := mockEntity{ID: uuid.Must(uuid.NewV4()), Owner: "alice", Balance: 42}
+	codec := estoria.JSONStateCodec[mockState]{}
+	want := mockState{ID: uuid.Must(uuid.NewV4()), Owner: "alice", Balance: 42}
 
-	data, err := marshaler.MarshalEntity(want)
+	data, err := codec.MarshalState(want)
 	if err != nil {
-		t.Fatalf("marshaling entity: %v", err)
+		t.Fatalf("marshaling state: %v", err)
 	}
 
-	var got mockEntity
-	if err := marshaler.UnmarshalEntity(data, &got); err != nil {
-		t.Fatalf("unmarshaling entity: %v", err)
+	var got mockState
+	if err := codec.UnmarshalState(data, &got); err != nil {
+		t.Fatalf("unmarshaling state: %v", err)
 	}
 
 	if got != want {
@@ -54,20 +45,20 @@ func TestJSONMarshaler_ValueEntity(t *testing.T) {
 	}
 }
 
-func TestJSONMarshaler_PointerEntity(t *testing.T) {
+func TestJSONStateCodec_PointerState(t *testing.T) {
 	t.Parallel()
 
-	marshaler := estoria.JSONMarshaler[*mockPointerEntity]{}
-	want := &mockPointerEntity{ID: uuid.Must(uuid.NewV4()), Owner: "alice", Balance: 42}
+	codec := estoria.JSONStateCodec[*mockPointerState]{}
+	want := &mockPointerState{ID: uuid.Must(uuid.NewV4()), Owner: "alice", Balance: 42}
 
-	data, err := marshaler.MarshalEntity(want)
+	data, err := codec.MarshalState(want)
 	if err != nil {
-		t.Fatalf("marshaling entity: %v", err)
+		t.Fatalf("marshaling state: %v", err)
 	}
 
-	got := &mockPointerEntity{}
-	if err := marshaler.UnmarshalEntity(data, &got); err != nil {
-		t.Fatalf("unmarshaling entity: %v", err)
+	got := &mockPointerState{}
+	if err := codec.UnmarshalState(data, &got); err != nil {
+		t.Fatalf("unmarshaling state: %v", err)
 	}
 
 	if *got != *want {
@@ -75,47 +66,47 @@ func TestJSONMarshaler_PointerEntity(t *testing.T) {
 	}
 }
 
-// TestJSONMarshaler_UnmarshalEntity_Invalid pins that a decode failure is reported rather
+// TestJSONStateCodec_UnmarshalState_Invalid pins that a decode failure is reported rather
 // than swallowed. SnapshottingStore relies on the error to decide whether to fall back to
-// full hydration instead of trusting a half-decoded entity.
-func TestJSONMarshaler_UnmarshalEntity_Invalid(t *testing.T) {
+// full hydration instead of trusting half-decoded state.
+func TestJSONStateCodec_UnmarshalState_Invalid(t *testing.T) {
 	t.Parallel()
 
-	var dest mockEntity
-	if err := (estoria.JSONMarshaler[mockEntity]{}).UnmarshalEntity([]byte(`{"balance":"not a number"}`), &dest); err == nil {
+	var dest mockState
+	if err := (estoria.JSONStateCodec[mockState]{}).UnmarshalState([]byte(`{"balance":"not a number"}`), &dest); err == nil {
 		t.Error("want an error for a type-mismatched field, got nil")
 	}
 }
 
-// mockEntityEvent is a minimal EntityEvent used to exercise the event marshaler.
-type mockEntityEvent struct {
+// mockDomainEvent is a minimal DomainEvent used to exercise the event codec.
+type mockDomainEvent struct {
 	Amount int64 `json:"amount"`
 }
 
-func (e *mockEntityEvent) EventType() string { return "mockentityevent" }
+func (e *mockDomainEvent) EventType() string { return "mockdomainevent" }
 
-func (e *mockEntityEvent) New() estoria.EntityEvent[mockEntity] {
-	return &mockEntityEvent{}
+func (e *mockDomainEvent) New() estoria.DomainEvent[mockState] {
+	return &mockDomainEvent{}
 }
 
-func (e *mockEntityEvent) ApplyTo(_ context.Context, entity mockEntity) (mockEntity, error) {
-	entity.Balance += e.Amount
-	return entity, nil
+func (e *mockDomainEvent) ApplyTo(_ context.Context, state mockState) (mockState, error) {
+	state.Balance += e.Amount
+	return state, nil
 }
 
-func TestJSONEntityEventMarshaler(t *testing.T) {
+func TestJSONDomainEventCodec(t *testing.T) {
 	t.Parallel()
 
-	marshaler := estoria.JSONEntityEventMarshaler[mockEntity]{}
+	codec := estoria.JSONDomainEventCodec[mockState]{}
 
-	data, err := marshaler.MarshalEntityEvent(&mockEntityEvent{Amount: 100})
+	data, err := codec.MarshalDomainEvent(&mockDomainEvent{Amount: 100})
 	if err != nil {
-		t.Fatalf("marshaling entity event: %v", err)
+		t.Fatalf("marshaling domain event: %v", err)
 	}
 
-	got := &mockEntityEvent{}
-	if err := marshaler.UnmarshalEntityEvent(data, got); err != nil {
-		t.Fatalf("unmarshaling entity event: %v", err)
+	got := &mockDomainEvent{}
+	if err := codec.UnmarshalDomainEvent(data, got); err != nil {
+		t.Fatalf("unmarshaling domain event: %v", err)
 	}
 
 	if got.Amount != 100 {
@@ -123,34 +114,34 @@ func TestJSONEntityEventMarshaler(t *testing.T) {
 	}
 }
 
-// TestJSONEntityEventMarshaler_UnmarshalEntityEvent_Invalid pins that a malformed payload is
+// TestJSONDomainEventCodec_UnmarshalDomainEvent_Invalid pins that a malformed payload is
 // reported. EventSourcedStore surfaces this as a hydration failure rather than applying an
 // event it could not read.
-func TestJSONEntityEventMarshaler_UnmarshalEntityEvent_Invalid(t *testing.T) {
+func TestJSONDomainEventCodec_UnmarshalDomainEvent_Invalid(t *testing.T) {
 	t.Parallel()
 
-	dest := &mockEntityEvent{}
-	if err := (estoria.JSONEntityEventMarshaler[mockEntity]{}).UnmarshalEntityEvent([]byte(`{`), dest); err == nil {
+	dest := &mockDomainEvent{}
+	if err := (estoria.JSONDomainEventCodec[mockState]{}).UnmarshalDomainEvent([]byte(`{`), dest); err == nil {
 		t.Error("want an error for malformed JSON, got nil")
 	}
 }
 
-// TestEntityEvent_ApplyTo covers the double satisfying the EntityEvent contract, so the
+// TestDomainEvent_ApplyTo covers the double satisfying the DomainEvent contract, so the
 // interface's shape is exercised rather than only its marshaling.
-func TestEntityEvent_ApplyTo(t *testing.T) {
+func TestDomainEvent_ApplyTo(t *testing.T) {
 	t.Parallel()
 
-	var event estoria.EntityEvent[mockEntity] = &mockEntityEvent{Amount: 25}
+	var event estoria.DomainEvent[mockState] = &mockDomainEvent{Amount: 25}
 
-	if got := event.EventType(); got != "mockentityevent" {
-		t.Errorf("want event type %q, got %q", "mockentityevent", got)
+	if got := event.EventType(); got != "mockdomainevent" {
+		t.Errorf("want event type %q, got %q", "mockdomainevent", got)
 	}
 
 	if got := event.New(); got == nil {
 		t.Error("want a new instance, got nil")
 	}
 
-	got, err := event.ApplyTo(t.Context(), mockEntity{Balance: 100})
+	got, err := event.ApplyTo(t.Context(), mockState{Balance: 100})
 	if err != nil {
 		t.Fatalf("applying event: %v", err)
 	}
@@ -160,17 +151,17 @@ func TestEntityEvent_ApplyTo(t *testing.T) {
 	}
 }
 
-// TestEntityFactory covers the factory signature aggregate stores are constructed with.
-func TestEntityFactory(t *testing.T) {
+// TestStateFactory covers the factory signature aggregate stores are constructed with.
+func TestStateFactory(t *testing.T) {
 	t.Parallel()
 
 	id := uuid.Must(uuid.NewV4())
 
-	var factory estoria.EntityFactory[mockEntity] = func(id uuid.UUID) mockEntity {
-		return mockEntity{ID: id}
+	var factory estoria.StateFactory[mockState] = func(id uuid.UUID) mockState {
+		return mockState{ID: id}
 	}
 
-	if got := factory(id); got.EntityID() != typeid.New("mockentity", id) {
-		t.Errorf("want the factory to build an entity carrying the given ID, got %s", got.EntityID())
+	if got := factory(id); got.ID != id {
+		t.Errorf("want the factory to build state carrying the given ID, got %s", got.ID)
 	}
 }

--- a/snapshotstore/eventstream/event_stream_store_test.go
+++ b/snapshotstore/eventstream/event_stream_store_test.go
@@ -178,7 +178,7 @@ type mockEntityEvent struct{}
 
 func (e *mockEntityEvent) EventType() string { return "incremented" }
 
-func (e *mockEntityEvent) New() estoria.EntityEvent[*mockEntity] { return &mockEntityEvent{} }
+func (e *mockEntityEvent) New() estoria.DomainEvent[*mockEntity] { return &mockEntityEvent{} }
 
 func (e *mockEntityEvent) ApplyTo(_ context.Context, entity *mockEntity) (*mockEntity, error) {
 	entity.Count++
@@ -197,7 +197,7 @@ func TestSnapshottingStore_VersionedLoad(t *testing.T) {
 		t.Fatalf("creating event store: %v", err)
 	}
 
-	inner, err := aggregatestore.New[*mockEntity](eventStore, newMockEntity,
+	inner, err := aggregatestore.New[*mockEntity](eventStore, "mockentity", newMockEntity,
 		aggregatestore.WithEventTypes[*mockEntity](&mockEntityEvent{}))
 	if err != nil {
 		t.Fatalf("creating inner store: %v", err)
@@ -216,9 +216,7 @@ func TestSnapshottingStore_VersionedLoad(t *testing.T) {
 	id := uuid.Must(uuid.NewV4())
 	aggregate := store.New(id)
 	for range 10 {
-		if err := aggregate.Append(&mockEntityEvent{}); err != nil {
-			t.Fatalf("appending event: %v", err)
-		}
+		aggregate.Append(&mockEntityEvent{})
 	}
 	if err := store.Save(t.Context(), aggregate, nil); err != nil {
 		t.Fatalf("saving aggregate: %v", err)
@@ -234,8 +232,8 @@ func TestSnapshottingStore_VersionedLoad(t *testing.T) {
 		if got.Version() != wantVersion {
 			t.Errorf("want version %d, got %d", wantVersion, got.Version())
 		}
-		if got.Entity().Count != int(wantVersion) {
-			t.Errorf("want count %d at version %d, got %d", wantVersion, wantVersion, got.Entity().Count)
+		if got.State().Count != int(wantVersion) {
+			t.Errorf("want count %d at version %d, got %d", wantVersion, wantVersion, got.State().Count)
 		}
 	}
 


### PR DESCRIPTION
An aggregate is identity, continuity, and state. The `Entity` interface conflated the first with the last: state reported its own typed ID, so every component needing the type name built an entity to ask (`hookable_store.go` and `cached_store.go` ran the state factory on every load just to learn a constant). Identity now lives on `Aggregate`, and the type name is supplied once, at store construction, validated, and exposed via `Store.AggregateType`.

## Changes

- **Remove `Entity.EntityID()`.** `Entity` survives as a deprecated alias for `any` so existing `[E estoria.Entity]` constraints keep compiling; it will be removed in v0.8.0. The constraint for new code is a plain `[S any]`.
- **The aggregate type name moves to the store constructor**: `aggregatestore.New(eventStore, "account", newAccount, ...)`. The name is half the aggregate's storage address, so the constructor rejects an empty name or one containing `_` (ambiguous in the `type_uuid` format). `Store` gains `AggregateType() string`; wrappers delegate it and compose typed IDs without fabricating state.
- **Rename the vocabulary to match**: `EntityEvent` → `DomainEvent`, `EntityFactory` → `StateFactory`, `EntityMarshaler` → `StateCodec` (impl `JSONStateCodec`), `EntityEventMarshaler` → `DomainEventCodec` (impl `JSONDomainEventCodec`), `WithEntityEventMarshaler` → `WithDomainEventCodec`, `WithSnapshotMarshaler` → `WithStateCodec`, `AggregateEvent[E, EE]` → `Event[S]`, `Aggregate.Entity()` → `Aggregate.State()`; type parameter `E` becomes `S` throughout.
- **Flatten `AggregateState` into `Aggregate`.** The aggregate holds its ID, version, state, and event queues directly. Public surface is four methods (`ID`, `Version`, `State`, `Append`); the mutation surface is unexported. `UnsavedEvents()` is removed — its only consumers were telemetry wrappers reading a count that the eventstore wrappers already emit as `events.length`.
- **`Append` no longer returns an error.** It has never returned a non-nil one; it only queues.
- **`AggregateCache` traffics in `CachedAggregate[S]{State, Version}`** — what cache implementations actually store — keyed by typed ID, and `CachedStore` composes the aggregate itself on a hit. Aggregate construction now has exactly one owner, and cache hits return freshly composed aggregates instead of a shared pointer.
- **Pin the full composition end to end**: a new test drives `EventSourcedStore` → `SnapshottingStore` → `CachedStore` → `HookableStore` through save, cached load, cold-cache load via snapshot, time travel, and not-found, asserting identity survives every path.

## Breaking changes

Every rename above is a compile break for consumers. Behavior changes: aggregate identity comes from the constructor-supplied type name (the string must match what `EntityID()` previously returned, byte for byte, or existing streams are unreachable), and `AggregateCache` implementations must adopt the entry-based interface. The `aggregate.unsaved_events` span attribute disappears from the DataDog and OpenTelemetry wrappers' traces.